### PR TITLE
Added WhiteBitNonceProvider

### DIFF
--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
@@ -1,25 +1,23 @@
-using CryptoExchange.Net;
-using CryptoExchange.Net.Authentication;
-using CryptoExchange.Net.Objects;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using CryptoExchange.Net.CommonObjects;
-using CryptoExchange.Net.Interfaces.CommonClients;
-using WhiteBit.Net.Interfaces.Clients.V4Api;
-using WhiteBit.Net.Objects.Options;
+using CoinEx.Net.Objects.Internal;
+using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Clients;
+using CryptoExchange.Net.Converters.MessageParsing;
 using CryptoExchange.Net.Converters.SystemTextJson;
 using CryptoExchange.Net.Interfaces;
+using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.SharedApis;
-using CryptoExchange.Net.Converters.MessageParsing;
-using System.Linq;
-using System.Text.Json.Serialization;
-using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using WhiteBit.Net.Interfaces.Clients.V4Api;
 using WhiteBit.Net.Objects.Models;
+using WhiteBit.Net.Objects.Options;
 
 namespace WhiteBit.Net.Clients.V4Api
 {
@@ -87,7 +85,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         /// <inheritdoc />
         protected override AuthenticationProvider CreateAuthenticationProvider(ApiCredentials credentials)
-            => new WhiteBitAuthenticationProvider(credentials);
+            => new WhiteBitAuthenticationProvider(credentials, ClientOptions.NonceProvider ?? new WhiteBitNonceProvider());
 
         internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
             => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
@@ -144,7 +142,7 @@ namespace WhiteBit.Net.Clients.V4Api
             => _timeSyncState.TimeOffset;
 
         /// <inheritdoc />
-        public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverDate = null) 
+        public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverDate = null)
             => WhiteBitExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverDate);
 
         /// <inheritdoc />

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CoinEx.Net.Objects.Internal;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Authentication;
 using CryptoExchange.Net.Clients;
@@ -82,7 +83,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         /// <inheritdoc />
         protected override AuthenticationProvider CreateAuthenticationProvider(ApiCredentials credentials)
-            => new WhiteBitAuthenticationProvider(credentials);
+            => new WhiteBitAuthenticationProvider(credentials, ClientOptions.NonceProvider ?? new WhiteBitNonceProvider());
 
         #region Trades
 
@@ -105,7 +106,7 @@ namespace WhiteBit.Net.Clients.V4Api
         /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default)
         {
-            var subscription = new WhiteBitSubscription<WhiteBitTradeUpdate>(_logger, "trades", symbols.ToArray(), x=> onMessage(x.WithSymbol(x.Data.Symbol)), false, true);
+            var subscription = new WhiteBitSubscription<WhiteBitTradeUpdate>(_logger, "trades", symbols.ToArray(), x => onMessage(x.WithSymbol(x.Data.Symbol)), false, true);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
         }
 
@@ -299,7 +300,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 "ordersExecuted_request",
                 true,
                 ct,
-                new {
+                new
+                {
                     market = symbol,
                     order_types = orderTypes.Select(x => (int)x).ToArray()
                 },
@@ -397,7 +399,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }, auth);
 
             var result = await QueryAsync(BaseAddress.AppendPath("ws"), query, ct).ConfigureAwait(false);
-            return result.As<T>(result.Data == null ? default: result.Data.Result);
+            return result.As<T>(result.Data == null ? default : result.Data.Result);
         }
 
         /// <inheritdoc />

--- a/WhiteBit.Net/Objects/Internal/WhiteBitNonceProvider.cs
+++ b/WhiteBit.Net/Objects/Internal/WhiteBitNonceProvider.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using CryptoExchange.Net.Interfaces;
+
+namespace CoinEx.Net.Objects.Internal
+{
+    internal class WhiteBitNonceProvider : INonceProvider
+    {
+        private readonly static object _nonceLock = new object();
+        private static long? _lastNonce;
+
+        /// <inheritdoc />
+        public long GetNonce()
+        {
+            lock (_nonceLock)
+            {
+                var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                if (_lastNonce.HasValue && nonce <= _lastNonce.Value)
+                    nonce = _lastNonce.Value + 1;
+                _lastNonce = nonce;
+                return nonce;
+            }
+        }
+    }
+}

--- a/WhiteBit.Net/Objects/Options/WhiteBitRestOptions.cs
+++ b/WhiteBit.Net/Objects/Options/WhiteBitRestOptions.cs
@@ -1,3 +1,4 @@
+using CryptoExchange.Net.Interfaces;
 using CryptoExchange.Net.Objects.Options;
 
 namespace WhiteBit.Net.Objects.Options
@@ -34,10 +35,16 @@ namespace WhiteBit.Net.Objects.Options
         /// </summary>
         public bool EnableNonceWindow { get; set; } = false;
 
+        /// <summary>
+        /// Optional nonce provider for signing requests.
+        /// </summary>
+        public INonceProvider? NonceProvider { get; set; }
+
         internal WhiteBitRestOptions Set(WhiteBitRestOptions targetOptions)
         {
             targetOptions = base.Set<WhiteBitRestOptions>(targetOptions);
             targetOptions.EnableNonceWindow = EnableNonceWindow;
+            targetOptions.NonceProvider = NonceProvider;
             targetOptions.V4Options = V4Options.Set(targetOptions.V4Options);
             return targetOptions;
         }

--- a/WhiteBit.Net/Objects/Options/WhiteBitSocketOptions.cs
+++ b/WhiteBit.Net/Objects/Options/WhiteBitSocketOptions.cs
@@ -1,3 +1,4 @@
+using CryptoExchange.Net.Interfaces;
 using CryptoExchange.Net.Objects.Options;
 
 namespace WhiteBit.Net.Objects.Options
@@ -25,6 +26,11 @@ namespace WhiteBit.Net.Objects.Options
         }
 
         /// <summary>
+        /// Optional nonce provider for signing requests.
+        /// </summary>
+        public INonceProvider? NonceProvider { get; set; }
+
+        /// <summary>
         /// V4 API options
         /// </summary>
         public SocketApiOptions V4Options { get; private set; } = new SocketApiOptions();
@@ -34,6 +40,7 @@ namespace WhiteBit.Net.Objects.Options
         {
             targetOptions = base.Set<WhiteBitSocketOptions>(targetOptions);
             targetOptions.V4Options = V4Options.Set(targetOptions.V4Options);
+            targetOptions.NonceProvider = NonceProvider;
             return targetOptions;
         }
     }

--- a/WhiteBit.Net/WhiteBit.Net.xml
+++ b/WhiteBit.Net/WhiteBit.Net.xml
@@ -4605,6 +4605,11 @@
             When true, request nonces are allowed to be out of order by the server at least as they are within a 5 second window. This allows concurrent requests to succeed during high traffic.
             </summary>
         </member>
+        <member name="P:WhiteBit.Net.Objects.Options.WhiteBitRestOptions.NonceProvider">
+            <summary>
+            Optional nonce provider for signing requests.
+            </summary>
+        </member>
         <member name="T:WhiteBit.Net.Objects.Options.WhiteBitSocketOptions">
             <summary>
             Options for the WhiteBitSocketClient
@@ -4618,6 +4623,11 @@
         <member name="M:WhiteBit.Net.Objects.Options.WhiteBitSocketOptions.#ctor">
             <summary>
             ctor
+            </summary>
+        </member>
+        <member name="P:WhiteBit.Net.Objects.Options.WhiteBitSocketOptions.NonceProvider">
+            <summary>
+            Optional nonce provider for signing requests.
             </summary>
         </member>
         <member name="P:WhiteBit.Net.Objects.Options.WhiteBitSocketOptions.V4Options">
@@ -5021,6 +5031,9 @@
             <summary>
             DEPRECATED; use <see cref="M:Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddWhiteBit(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{WhiteBit.Net.Objects.Options.WhiteBitOptions})" /> instead
             </summary>
+        </member>
+        <member name="M:CoinEx.Net.Objects.Internal.WhiteBitNonceProvider.GetNonce">
+            <inheritdoc />
         </member>
     </members>
 </doc>


### PR DESCRIPTION
Implemented a nonce provider that ensures that each nonce is only used once. This will fix double spending nonces when nonceWindow is used. I tried to implement this provider as you did in your other libs. 


Official Documentation -> "About Nonce Values" (https://docs.whitebit.com/private/http-auth/)
-> "Each nonce must be unique to prevent double processing"