### PR TITLE
Updated WhiteBitRestMessageHandler.ParseErrorResponse() code mapping

### DIFF
--- a/WhiteBit.Net/Clients/MessageHandlers/WhiteBitRestMessageHandler.cs
+++ b/WhiteBit.Net/Clients/MessageHandlers/WhiteBitRestMessageHandler.cs
@@ -55,7 +55,10 @@ namespace WhiteBit.Net.Clients.MessageHandlers
             }
             else
             {
-                return new ServerError(ErrorInfo.Unknown with { Message = string.Join(", ", errors.Select(x => $"Error field '{x.Key}': {string.Join(" & ", x.Value)}")) } );
+                var message = string.Join(", ", errors.Select(x => $"Error field '{x.Key}': {string.Join(" & ", x.Value)}"));
+                return code.HasValue ?
+                    new ServerError(code.Value, _errorMapping.GetErrorInfo(code.Value.ToString(), message)) :
+                    new ServerError(ErrorInfo.Unknown with { Message = message });
             }
         }
     }


### PR DESCRIPTION
There was a scenario where the error code was not transmitted correctly. With this change, all errors triggered in my tests are now parsed correctly.