### PR TITLE
Fixed GetConvertHistoryAsync from/to parameter parsing

### DIFF
--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
@@ -62,8 +62,8 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.AddOptional("fromTicker", fromAsset);
             parameters.AddOptional("toTicker", toAsset);
             parameters.AddOptional("quoteId", quoteId);
-            parameters.AddOptionalMillisecondsString("from", startTime);
-            parameters.AddOptionalMillisecondsString("to", endTime);
+            parameters.AddOptionalSecondsString("from", startTime);
+            parameters.AddOptionalSecondsString("to", endTime);
             parameters.AddOptional("limit", limit);
             parameters.AddOptional("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,


### PR DESCRIPTION
The from/to parameters must be specified in Unix seconds. With the old code, there was an error indicating that the values were invalid.

Official Docs:
https://docs.whitebit.com/api-reference/convert/convert-history#body-from