### PR TITLE
 Added SymbolType.TradFiFutures enum value

### DIFF
--- a/WhiteBit.Net/Enums/SymbolType.cs
+++ b/WhiteBit.Net/Enums/SymbolType.cs
@@ -19,6 +19,11 @@ namespace WhiteBit.Net.Enums
         /// ["<c>futures</c>"] Futures symbol
         /// </summary>
         [Map("futures")]
-        Futures
+        Futures,
+        /// <summary>
+        /// ["<c>tradfiFutures</c>"] TradFi futures symbol
+        /// </summary>
+        [Map("tradfiFutures")]
+        TradFiFutures
     }
 }


### PR DESCRIPTION
Fix for the following warning:
`16:12:35.917 | Warning     | CryptoExchange | Cannot map enum value. EnumType: WhiteBit.Net.Enums.SymbolType, Value: tradfiFutures, Known values: [spot: Spot, futures: Futures]. If you think tradfiFutures should be added please open an issue on the Github repo`