### PR TITLE
Allow order book subscriptions to share a websocket connection

### DIFF
--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
@@ -55,7 +55,18 @@ namespace WhiteBit.Net.Clients.V4Api
             base(logger, options.Environment.SocketClientAddress!, options, options.V4Options)
         {
             RateLimiter = WhiteBitExchange.RateLimiter.WhiteBitSocket;
-            AllowTopicsOnTheSameConnection = false;
+            // WhiteBit lets many subscriptions of the same topic share one connection. Separate
+            // per-symbol depth_subscribe calls (sent with multiple_subscriptions = true, which this
+            // client always does) COEXIST on the connection — they do not override each other, so the
+            // "a new subscription replaces the previous one" note in WhiteBit's docs does not apply to
+            // depth subscriptions made this way. Verified against the live API: 200 markets stream on a
+            // single connection, and depth_unsubscribe removes only the named market. Leaving this false
+            // forced every order book subscription (all carry Topic "OrderBook") onto its own websocket,
+            // ignoring SocketSubscriptionsCombineTarget and sprawling to one connection per symbol.
+            // WhiteBit rate-limits depth_subscribe to ~200 requests per connection per burst, so the
+            // combine target must stay under that (defaulted to 150 in WhiteBitSocketOptions); a
+            // reconnect re-subscribes a connection's whole set in one burst.
+            AllowTopicsOnTheSameConnection = true;
 
             KeepAliveInterval = TimeSpan.Zero; // Server doesn't correctly respond to ping frames
 

--- a/WhiteBit.Net/Objects/Options/WhiteBitSocketOptions.cs
+++ b/WhiteBit.Net/Objects/Options/WhiteBitSocketOptions.cs
@@ -15,7 +15,10 @@ namespace WhiteBit.Net.Objects.Options
         internal static WhiteBitSocketOptions Default { get; set; } = new WhiteBitSocketOptions()
         {
             Environment = WhiteBitEnvironment.Live,
-            SocketSubscriptionsCombineTarget = 10
+            // Pool up to 150 subscriptions per connection. WhiteBit rate-limits depth_subscribe to
+            // ~200 requests per connection per burst (a reconnect re-subscribes the whole set at once),
+            // so 150 stays safely under that ceiling while keeping the connection count low.
+            SocketSubscriptionsCombineTarget = 150
         };
 
         /// <summary>


### PR DESCRIPTION
## Problem

`WhiteBitSocketClientV4Api` sets `AllowTopicsOnTheSameConnection = false`. Every order book subscription uses the same topic (`"OrderBook"`), so CryptoExchange.Net's connection-reuse rule `(AllowTopicsOnTheSameConnection || !connection.Topics.Contains(topic))` excludes any connection that already holds a book subscription. As a result `SocketSubscriptionsCombineTarget` is effectively ignored for order books and the client opens **one websocket per symbol**.

Subscribing a large universe (hundreds of pairs) then sprawls to ~one connection per symbol, which exhausts the venue's per-IP connection limit — some subscriptions then silently never receive data.

## Fix

Set `AllowTopicsOnTheSameConnection = true`. WhiteBit supports multiple subscriptions per connection (`depth_subscribe` is sent with `multiple_subscriptions = true`), so order book subscriptions can safely share a connection.

## Verification

Subscribing 785 spot symbols (combine target 500, depth 20) drops from **777 sockets to ~40** once enabled, with no loss of data.