### PR TITLE
CryptoExchange.Net V12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ description: Use WhiteBit.Net when generating C#/.NET code that interacts with t
 
 ## Quick Decision
 
-If the user asks for WhiteBit API access in C#/.NET, use `WhiteBit.Net`. Do not write raw `HttpClient` calls to WhiteBit endpoints. The library handles authentication, request signing, rate limiting, response parsing, WebSocket reconnection, and the `WebCallResult<T>` / `CallResult<T>` error model.
+If the user asks for WhiteBit API access in C#/.NET, use `WhiteBit.Net`. Do not write raw `HttpClient` calls to WhiteBit endpoints. The library handles authentication, request signing, rate limiting, response parsing, WebSocket reconnection, and the `HttpResult<T>` / `WebSocketResult<T>` error model.
 
 For multi-exchange code, use `CryptoExchange.Net.SharedApis` through `client.V4Api.SharedClient`.
 
@@ -43,7 +43,7 @@ var restClient = new WhiteBitRestClient(options =>
 
 ## Core Pattern: Result Handling
 
-REST methods return `WebCallResult<T>` or `WebCallResult`. WebSocket requests and subscriptions return `CallResult<T>`. Always check `.Success` before reading `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`. WebSocket requests and subscriptions return `WebSocketResult<T>`. Always check `.Success` before reading `.Data`.
 
 ```csharp
 var tickers = await publicClient.V4Api.ExchangeData.GetTickersAsync();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ description: Use WhiteBit.Net when generating C#/.NET code that interacts with t
 
 ## Quick Decision
 
-If the user asks for WhiteBit API access in C#/.NET, use `WhiteBit.Net`. Do not write raw `HttpClient` calls to WhiteBit endpoints. The library handles authentication, request signing, rate limiting, response parsing, WebSocket reconnection, and the `HttpResult<T>` / `WebSocketResult<T>` error model.
+If the user asks for WhiteBit API access in C#/.NET, use `WhiteBit.Net`. Do not write raw `HttpClient` calls to WhiteBit endpoints. The library handles authentication, request signing, rate limiting, response parsing, WebSocket reconnection, and the `HttpResult<T>` / `QueryResult<T>` / `WebSocketResult<UpdateSubscription>` error model.
 
 For multi-exchange code, use `CryptoExchange.Net.SharedApis` through `client.V4Api.SharedClient`.
 
@@ -43,7 +43,7 @@ var restClient = new WhiteBitRestClient(options =>
 
 ## Core Pattern: Result Handling
 
-REST methods return `HttpResult<T>` or `HttpResult`. WebSocket requests and subscriptions return `WebSocketResult<T>`. Always check `.Success` before reading `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`. WebSocket request/response methods return `QueryResult<T>`. WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`. Always check `.Success` before reading `.Data`.
 
 ```csharp
 var tickers = await publicClient.V4Api.ExchangeData.GetTickersAsync();
@@ -179,6 +179,8 @@ Console.WriteLine(ticker.Data.LastPrice);
 ```
 
 Shared REST interfaces implemented by WhiteBit include spot symbols, spot tickers, recent trades, order book, balances, assets, deposits, withdrawals, spot orders, futures symbols, futures tickers, leverage, open interest, position history, futures orders, fees, trigger orders, TP/SL, book ticker, funding rate, and transfers.
+
+Use `new WhiteBitRestClient().V4Api.SharedClient.Discover()` when code needs runtime metadata about supported shared interfaces and endpoint options.
 
 ## Dependency Injection
 

--- a/Examples/ai-friendly/04-multi-exchange.cs
+++ b/Examples/ai-friendly/04-multi-exchange.cs
@@ -15,6 +15,7 @@ using WhiteBit.Net.Clients;
 // WhiteBit exposes a `.SharedClient` property on V4Api.
 // SharedClient implements interfaces like ISpotTickerRestClient, ISpotOrderRestClient,
 // IBalanceRestClient, and more: a common abstraction across exchange libraries.
+// Use SharedClient.Discover() when you need runtime capability metadata.
 
 ISpotTickerRestClient whiteBitShared = new WhiteBitRestClient().V4Api.SharedClient;
 
@@ -58,6 +59,7 @@ async Task PrintTicker(ISpotTickerRestClient client, SharedSymbol symbol)
 //   IPositionSocketClient
 
 // ---- WEBSOCKET EXAMPLE: SHARED SUBSCRIPTION ----
+// Shared socket subscriptions return WebSocketResult<UpdateSubscription>.
 var whiteBitSocket = new WhiteBitSocketClient();
 ITickerSocketClient whiteBitTickerSocket = whiteBitSocket.V4Api.SharedClient;
 

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -1,6 +1,6 @@
 // 05-error-handling.cs
 //
-// Demonstrates: WebCallResult patterns, retry logic, common WhiteBit routing
+// Demonstrates: HttpResult patterns, retry logic, common WhiteBit routing
 // and validation scenarios.
 //
 // Setup: dotnet add package WhiteBit.Net
@@ -16,7 +16,7 @@ var client = new WhiteBitRestClient(options =>
 });
 
 // ---- 1. THE BASIC PATTERN ----
-// Every REST method returns WebCallResult<T> or WebCallResult.
+// Every REST method returns HttpResult<T> or HttpResult.
 // .Success is true/false. .Data is valid only when .Success is true.
 // .Error contains structured error info when .Success is false.
 
@@ -39,11 +39,11 @@ else
 // Retry only on transient errors: network blips, temporary server errors, rate limits.
 // Do not retry validation errors, permission errors, or insufficient balance.
 
-async Task<WebCallResult<T>> WithRetry<T>(
-    Func<Task<WebCallResult<T>>> call,
+async Task<HttpResult<T>> WithRetry<T>(
+    Func<Task<HttpResult<T>>> call,
     int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
         last = await call();
@@ -134,7 +134,7 @@ if (!order.Success)
 }
 
 // ---- 5. EXCEPTIONS VS ERROR RESULTS ----
-// WhiteBit.Net returns exchange and network errors via WebCallResult.Error.
+// WhiteBit.Net returns exchange and network errors via HttpResult.Error.
 // Exceptions are usually for misconfiguration, disposal, cancellation, or programming errors.
 
 // Common variations:

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -16,7 +16,9 @@ var client = new WhiteBitRestClient(options =>
 });
 
 // ---- 1. THE BASIC PATTERN ----
-// Every REST method returns HttpResult<T> or HttpResult.
+// Every direct and SharedApis REST method returns HttpResult<T> or HttpResult.
+// WebSocket request/response methods return QueryResult<T>.
+// WebSocket subscriptions return WebSocketResult<UpdateSubscription>.
 // .Success is true/false. .Data is valid only when .Success is true.
 // .Error contains structured error info when .Success is false.
 

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -15,7 +15,7 @@ These examples are optimized for AI coding assistants and quick onboarding. Each
 | `02-collateral-futures.cs` | Collateral/futures leverage, market order, open position retrieval, reduce-only close |
 | `03-websocket.cs` | Ticker updates, kline updates, private order and balance streams, proper teardown |
 | `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern for exchange-agnostic code |
-| `05-error-handling.cs` | `WebCallResult` patterns, retry, common validation and routing mistakes |
+| `05-error-handling.cs` | `HttpResult` patterns, retry, common validation and routing mistakes |
 
 ## Running
 

--- a/WhiteBit.Net.UnitTests/RestRequestTests.cs
+++ b/WhiteBit.Net.UnitTests/RestRequestTests.cs
@@ -101,7 +101,7 @@ namespace WhiteBit.Net.UnitTests
             await tester.ValidateAsync(client => client.V4Api.CollateralTrading.CancelOcoOrderAsync("123", 123), "CancelOcoOrder");
         }
 
-        private bool IsAuthenticated(WebCallResult result)
+        private bool IsAuthenticated(IHttpResult result)
         {
             return result.RequestHeaders?.Any(x => x.Key == "X-TXC-SIGNATURE") == true;
         }

--- a/WhiteBit.Net.UnitTests/WhiteBitRestClientTests.cs
+++ b/WhiteBit.Net.UnitTests/WhiteBitRestClientTests.cs
@@ -34,13 +34,12 @@ namespace WhiteBit.Net.UnitTests
                     return headers["X-TXC-SIGNATURE"].ToString();
                 },
                 "e164832d38f40692420d44786f8dbc98a46af816ed6c30dbc5d6178e71e63f491a4b6dbfea93c887f50c570d4b403dd61fe2432908754f49f904d06c51c84680",
-                new Dictionary<string, object>
+                new Parameters(WhiteBitExchange._parameterSerializationSettings)
                 {
                     { "market", "ETH_USDT" },
                 },
                 DateTimeConverter.ParseFromDouble(1499827320559),
-                true,
-                false);
+                true);
         }
 
         [Test]

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
@@ -53,16 +53,16 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region constructor/destructor
-        internal WhiteBitRestClientV4Api(ILogger logger, HttpClient? httpClient, WhiteBitRestOptions options)
-            : base(logger, WhiteBitExchange.ExchangeName, httpClient, options.Environment.RestClientAddress, options, options.V4Options)
+        internal WhiteBitRestClientV4Api(ILoggerFactory? loggerFactory, HttpClient? httpClient, WhiteBitRestOptions options)
+            : base(loggerFactory, WhiteBitExchange.ExchangeName, httpClient, options.Environment.RestClientAddress, options, options.V4Options)
         {
             Account = new WhiteBitRestClientV4ApiAccount(this);
             Convert = new WhiteBitRestClientV4ApiConvert(this);
             Codes = new WhiteBitRestClientV4ApiCodes(this);
             SubAccount = new WhiteBitRestClientV4ApiSubAccount(this);
-            ExchangeData = new WhiteBitRestClientV4ApiExchangeData(logger, this);
-            Trading = new WhiteBitRestClientV4ApiTrading(logger, this);
-            CollateralTrading = new WhiteBitRestClientV4ApiCollateralTrading(logger, this);
+            ExchangeData = new WhiteBitRestClientV4ApiExchangeData(_logger, this);
+            Trading = new WhiteBitRestClientV4ApiTrading(_logger, this);
+            CollateralTrading = new WhiteBitRestClientV4ApiCollateralTrading(_logger, this);
         }
         #endregion
 

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
@@ -73,38 +73,18 @@ namespace WhiteBit.Net.Clients.V4Api
         protected override WhiteBitAuthenticationProvider CreateAuthenticationProvider(WhiteBitCredentials credentials)
             => new WhiteBitAuthenticationProvider(credentials, ClientOptions.NonceProvider ?? new WhiteBitNonceProvider());
 
-        internal Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<HttpResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<object>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            var result = await base.SendAsync<Unit>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             if (!result.Success && result.Error is DeserializeError)
-                return new HttpResult<object>(result.Exchange, result.Data, null)
-                {
-                    ResponseStatusCode = result.ResponseStatusCode,
-                    HttpVersion = result.HttpVersion,
-                    ResponseHeaders = result.ResponseHeaders,
-                    ResponseTime = result.ResponseTime,
-                    ResponseLength = result.ResponseLength,
-                    OriginalData = result.OriginalData,
-                    RequestId = result.RequestId,
-                    RequestUrl = result.RequestUrl,
-                    RequestBody = result.RequestBody,
-                    RequestMethod = result.RequestMethod,
-                    RequestHeaders = result.RequestHeaders,
-                    DataSource = result.DataSource,
-                };
+                return HttpResult.Ok(result); // Deserialize error without data expected is not an issue
 
             return result;
         }
 
-        internal Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<HttpResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
         {
-            var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            var result = await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4Api.cs
@@ -54,7 +54,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region constructor/destructor
         internal WhiteBitRestClientV4Api(ILogger logger, HttpClient? httpClient, WhiteBitRestOptions options)
-            : base(logger, httpClient, options.Environment.RestClientAddress, options, options.V4Options)
+            : base(logger, WhiteBitExchange.ExchangeName, httpClient, options.Environment.RestClientAddress, options, options.V4Options)
         {
             Account = new WhiteBitRestClientV4ApiAccount(this);
             Convert = new WhiteBitRestClientV4ApiConvert(this);
@@ -73,26 +73,43 @@ namespace WhiteBit.Net.Clients.V4Api
         protected override WhiteBitAuthenticationProvider CreateAuthenticationProvider(WhiteBitCredentials credentials)
             => new WhiteBitAuthenticationProvider(credentials, ClientOptions.NonceProvider ?? new WhiteBitNonceProvider());
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
             => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
 
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            var result = await base.SendAsync<object>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success && result.Error is DeserializeError)
+                return new HttpResult<object>(result.Exchange, result.Data, null)
+                {
+                    ResponseStatusCode = result.ResponseStatusCode,
+                    HttpVersion = result.HttpVersion,
+                    ResponseHeaders = result.ResponseHeaders,
+                    ResponseTime = result.ResponseTime,
+                    ResponseLength = result.ResponseLength,
+                    OriginalData = result.OriginalData,
+                    RequestId = result.RequestId,
+                    RequestUrl = result.RequestUrl,
+                    RequestBody = result.RequestBody,
+                    RequestMethod = result.RequestMethod,
+                    RequestHeaders = result.RequestHeaders,
+                    DataSource = result.DataSource,
+                };
+
             return result;
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
             => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
 
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
         {
             var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync()
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync()
             => ExchangeData.GetServerTimeAsync();
 
         /// <inheritdoc />

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiAccount.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiAccount.cs
@@ -29,7 +29,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitMainBalance[]>> GetMainBalancesAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitMainBalance>>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
@@ -38,7 +38,7 @@ namespace WhiteBit.Net.Clients.V4Api
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return HttpResult.Ok(result, result.Data?.Values.ToArray());
+            return HttpResult.Ok(result, result.Data.Values.ToArray());
         }
 
         #endregion
@@ -51,7 +51,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
             parameters.Add("network", network);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/address", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/address", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); 
             var result = await _baseClient.SendAsync<WhiteBitDepositAddressInfo>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -66,7 +66,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/trade-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitTradeBalance>>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
@@ -75,7 +75,7 @@ namespace WhiteBit.Net.Clients.V4Api
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return HttpResult.Ok(result, result.Data?.Values.ToArray());
+            return HttpResult.Ok(result, result.Data.Values.ToArray());
         }
 
         #endregion
@@ -108,7 +108,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (customer.Any())
             parameters.Add("customer", customer);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/fiat-deposit-url", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/fiat-deposit-url", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositUrl>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -143,7 +143,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (!deductFeeFromOutput)
                 path = "/api/v4/main-account/withdraw-pay";
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, path, WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, path, WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -161,7 +161,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("to", toAccount);
             parameters.Add("ticker", asset);
             parameters.Add("amount", quantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/transfer", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/transfer", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -183,7 +183,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("uniqueId", uniqueId);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositWithdrawals>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -200,7 +200,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("ticker", asset);
             parameters.Add("network", network);
             parameters.Add("type", addressType);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/create-new-address", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/create-new-address", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositAddressInfo>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -214,7 +214,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitDepositWithdrawalSetting[]>> GetDepositWithdrawalSettingsAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositWithdrawalSetting[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -233,7 +233,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("to", endTime);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/mining/rewards", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/mining/rewards", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitMiningRewards>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -248,7 +248,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -262,7 +262,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitCollateralSummary[]>> GetCollateralBalanceSummaryAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/balance-summary", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/balance-summary", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitCollateralSummary[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -275,7 +275,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitCollateralAccountSummary>> GetCollateralAccountSummaryAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/summary", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/summary", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCollateralAccountSummary>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -304,6 +304,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, 
+                _baseClient.BaseAddress,
                 "/api/v4/collateral-account/funding-history", 
                 WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -318,7 +319,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("leverage", leverage);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/leverage", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/leverage", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitLeverage>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -334,7 +335,7 @@ namespace WhiteBit.Net.Clients.V4Api
         //{
         //    var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
         //    parameters.Add("market", symbol);
-        //    var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/market/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+        //    var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/market/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
         //    return await _baseClient.SendAsync<WhiteBitTradingFee>(request, parameters, null, ct).ConfigureAwait(false);
         //}
 
@@ -345,7 +346,7 @@ namespace WhiteBit.Net.Clients.V4Api
         /// <inheritdoc />
         public async Task<HttpResult<WhiteBitTradingFees>> GetTradingFeesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/market/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/market/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             return await _baseClient.SendAsync<WhiteBitTradingFees>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -357,7 +358,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitHedgeMode>> GetHedgeModeAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/hedge-mode", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/hedge-mode", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitHedgeMode>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -371,7 +372,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("hedgeMode", enableHedgeMode);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/hedge-mode/update", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/hedge-mode/update", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitHedgeMode>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -381,9 +382,12 @@ namespace WhiteBit.Net.Clients.V4Api
 
         internal async Task<HttpResult<string>> GetWebsocketTokenAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/profile/websocket_token", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/profile/websocket_token", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitToken>(request, null, ct).ConfigureAwait(false);
-            return HttpResult.Ok(result, result.Data?.Token);
+            if (!result.Success)
+                return HttpResult.Fail<string>(result);
+
+            return HttpResult.Ok(result, result.Data.Token);
         }
     }
 }

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiAccount.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiAccount.cs
@@ -26,19 +26,19 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Main Balances
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitMainBalance[]>> GetMainBalancesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitMainBalance[]>> GetMainBalancesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitMainBalance>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<WhiteBitMainBalance[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitMainBalance[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return result.As<WhiteBitMainBalance[]>(result.Data?.Values.ToArray());
+            return HttpResult.Ok(result, result.Data?.Values.ToArray());
         }
 
         #endregion
@@ -46,11 +46,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Deposit Address
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitDepositAddressInfo>> GetDepositAddressAsync(string asset, string? network = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitDepositAddressInfo>> GetDepositAddressAsync(string asset, string? network = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
-            parameters.AddOptional("network", network);
+            parameters.Add("network", network);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/address", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); 
             var result = await _baseClient.SendAsync<WhiteBitDepositAddressInfo>(request, parameters, ct).ConfigureAwait(false);
@@ -62,20 +62,20 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Spot Balances
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(string? asset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(string? asset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("ticker", asset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("ticker", asset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitTradeBalance>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<WhiteBitTradeBalance[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitTradeBalance[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return result.As<WhiteBitTradeBalance[]>(result.Data?.Values.ToArray());
+            return HttpResult.Ok(result, result.Data?.Values.ToArray());
         }
 
         #endregion
@@ -83,26 +83,26 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Fiat Deposit Address
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitDepositUrl>> GetFiatDepositAddressAsync(string asset, string provider, decimal quantity, string clientOrderId, string? successLink = null, string? failureLink = null, string? returnLink = null, string? customerFirstName = null, string? customerLastName = null, string? customerEmail = null, string? customerAddressLine1 = null, string? customerAddressLine2 = null, string? customerCity = null, string? customerZipCode = null, string? customerCountryCode = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitDepositUrl>> GetFiatDepositAddressAsync(string asset, string provider, decimal quantity, string clientOrderId, string? successLink = null, string? failureLink = null, string? returnLink = null, string? customerFirstName = null, string? customerLastName = null, string? customerEmail = null, string? customerAddressLine1 = null, string? customerAddressLine2 = null, string? customerCity = null, string? customerZipCode = null, string? customerCountryCode = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
             parameters.Add("provider", provider);
-            parameters.AddString("amount", quantity);
+            parameters.Add("amount", quantity);
             parameters.Add("uniqueId", clientOrderId);
-            parameters.AddOptional("successLink", successLink);
-            parameters.AddOptional("failureLink", failureLink);
-            parameters.AddOptional("returnLink", returnLink);
-            var customer = new ParameterCollection();
-            customer.AddOptional("firstName", customerFirstName);
-            customer.AddOptional("lastName", customerLastName);
-            customer.AddOptional("email", customerEmail);
-            var address = new ParameterCollection();
-            address.AddOptional("addressLine1", customerAddressLine1);
-            address.AddOptional("addressLine2", customerAddressLine2);
-            address.AddOptional("city", customerCity);
-            address.AddOptional("zipCode", customerZipCode);
-            address.AddOptional("countryCode", customerCountryCode);
+            parameters.Add("successLink", successLink);
+            parameters.Add("failureLink", failureLink);
+            parameters.Add("returnLink", returnLink);
+            var customer = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            customer.Add("firstName", customerFirstName);
+            customer.Add("lastName", customerLastName);
+            customer.Add("email", customerEmail);
+            var address = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            address.Add("addressLine1", customerAddressLine1);
+            address.Add("addressLine2", customerAddressLine2);
+            address.Add("city", customerCity);
+            address.Add("zipCode", customerZipCode);
+            address.Add("countryCode", customerCountryCode);
             if (address.Any())
                 customer.Add("address", address);
             if (customer.Any())
@@ -119,23 +119,23 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Withdraw
 
         /// <inheritdoc />
-        public async Task<WebCallResult> WithdrawAsync(string asset, decimal quantity, string address, string uniqueId, bool deductFeeFromOutput, string? memo = null, string? provider = null, string? network = null, bool? partialEnable = null, string? beneficiaryFirstName = null, string? beneficiaryLastName = null, string? beneficiaryTin = null, string? beneficiaryPhone = null, string? beneficiaryEmail = null, CancellationToken ct = default)
+        public async Task<HttpResult> WithdrawAsync(string asset, decimal quantity, string address, string uniqueId, bool deductFeeFromOutput, string? memo = null, string? provider = null, string? network = null, bool? partialEnable = null, string? beneficiaryFirstName = null, string? beneficiaryLastName = null, string? beneficiaryTin = null, string? beneficiaryPhone = null, string? beneficiaryEmail = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
-            parameters.AddString("amount", quantity);
+            parameters.Add("amount", quantity);
             parameters.Add("address", address);
             parameters.Add("uniqueId", uniqueId);
-            parameters.AddOptional("memo", memo);
-            parameters.AddOptional("provider", provider);
-            parameters.AddOptional("network", network);
-            parameters.AddOptional("partialEnable", partialEnable);
-            var beneficiary = new ParameterCollection();
-            beneficiary.AddOptional("firstName", beneficiaryFirstName);
-            beneficiary.AddOptional("lastName", beneficiaryLastName);
-            beneficiary.AddOptional("tin", beneficiaryTin);
-            beneficiary.AddOptional("phone", beneficiaryPhone);
-            beneficiary.AddOptional("email", beneficiaryEmail);
+            parameters.Add("memo", memo);
+            parameters.Add("provider", provider);
+            parameters.Add("network", network);
+            parameters.Add("partialEnable", partialEnable);
+            var beneficiary = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            beneficiary.Add("firstName", beneficiaryFirstName);
+            beneficiary.Add("lastName", beneficiaryLastName);
+            beneficiary.Add("tin", beneficiaryTin);
+            beneficiary.Add("phone", beneficiaryPhone);
+            beneficiary.Add("email", beneficiaryEmail);
             if (beneficiary.Any())
                 parameters.Add("beneficiary", beneficiary);
 
@@ -154,13 +154,13 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Transfer
 
         /// <inheritdoc />
-        public async Task<WebCallResult> TransferAsync(AccountType fromAccount, AccountType toAccount, string asset, decimal quantity, CancellationToken ct = default)
+        public async Task<HttpResult> TransferAsync(AccountType fromAccount, AccountType toAccount, string asset, decimal quantity, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("from", fromAccount);
-            parameters.AddEnum("to", toAccount);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("from", fromAccount);
+            parameters.Add("to", toAccount);
             parameters.Add("ticker", asset);
-            parameters.AddString("amount", quantity);
+            parameters.Add("amount", quantity);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/transfer", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
@@ -172,17 +172,17 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Deposit Withdrawal History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitDepositWithdrawals>> GetDepositWithdrawalHistoryAsync(TransactionType? type = null, string? asset = null, string? address = null, string? memo = null, string? addresses = null, string? uniqueId = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitDepositWithdrawals>> GetDepositWithdrawalHistoryAsync(TransactionType? type = null, string? asset = null, string? address = null, string? memo = null, string? addresses = null, string? uniqueId = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalEnumAsInt("transactionMethod", type);
-            parameters.AddOptional("ticker", asset);
-            parameters.AddOptional("address", address);
-            parameters.AddOptional("memo", memo);
-            parameters.AddOptional("addresses", addresses);
-            parameters.AddOptional("uniqueId", uniqueId);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.AddAsInt("transactionMethod", type);
+            parameters.Add("ticker", asset);
+            parameters.Add("address", address);
+            parameters.Add("memo", memo);
+            parameters.Add("addresses", addresses);
+            parameters.Add("uniqueId", uniqueId);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositWithdrawals>(request, parameters, ct).ConfigureAwait(false);
@@ -194,12 +194,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Create Deposit Address
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitDepositAddressInfo>> CreateDepositAddressAsync(string asset, string? network = null, string? addressType = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitDepositAddressInfo>> CreateDepositAddressAsync(string asset, string? network = null, string? addressType = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
-            parameters.AddOptional("network", network);
-            parameters.AddOptional("type", addressType);
+            parameters.Add("network", network);
+            parameters.Add("type", addressType);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/create-new-address", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositAddressInfo>(request, parameters, ct).ConfigureAwait(false);
@@ -211,9 +211,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Deposit Withdrawal Settings
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitDepositWithdrawalSetting[]>> GetDepositWithdrawalSettingsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitDepositWithdrawalSetting[]>> GetDepositWithdrawalSettingsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositWithdrawalSetting[]>(request, parameters, ct).ConfigureAwait(false);
@@ -225,14 +225,14 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Mining Reward History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitMiningRewards>> GetMiningRewardHistoryAsync(string? accountName = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitMiningRewards>> GetMiningRewardHistoryAsync(string? accountName = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("account", accountName);
-            parameters.AddOptionalMilliseconds("from", startTime);
-            parameters.AddOptionalMilliseconds("to", endTime);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("account", accountName);
+            parameters.Add("from", startTime);
+            parameters.Add("to", endTime);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/mining/rewards", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitMiningRewards>(request, parameters, ct).ConfigureAwait(false);
@@ -244,10 +244,10 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Collateral Balances
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, decimal>>> GetCollateralBalancesAsync(string? asset = null, CancellationToken ct = default)
+        public async Task<HttpResult<Dictionary<string, decimal>>> GetCollateralBalancesAsync(string? asset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("ticker", asset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("ticker", asset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/balance", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
@@ -259,9 +259,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Collateral Balance Summary
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitCollateralSummary[]>> GetCollateralBalanceSummaryAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitCollateralSummary[]>> GetCollateralBalanceSummaryAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/balance-summary", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitCollateralSummary[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -272,9 +272,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Collateral Account Summary
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitCollateralAccountSummary>> GetCollateralAccountSummaryAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitCollateralAccountSummary>> GetCollateralAccountSummaryAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/summary", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCollateralAccountSummary>(request, parameters, ct).ConfigureAwait(false);
@@ -286,7 +286,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Account Funding History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitAccountFundingHistories>> GetAccountFundingHistoryAsync(
+        public async Task<HttpResult<WhiteBitAccountFundingHistories>> GetAccountFundingHistoryAsync(
             string symbol,
             DateTime? startTime = null,
             DateTime? endTime = null,
@@ -294,15 +294,15 @@ namespace WhiteBit.Net.Clients.V4Api
             int? offset = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
 
-            parameters.AddOptionalSeconds("startDate", startTime);
-            parameters.AddOptionalSeconds("endDate", endTime);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            parameters.Add("startDate", startTime);
+            parameters.Add("endDate", endTime);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, 
                 "/api/v4/collateral-account/funding-history", 
                 WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
@@ -314,9 +314,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Set Account Leverage
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitLeverage>> SetAccountLeverageAsync(int leverage, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitLeverage>> SetAccountLeverageAsync(int leverage, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("leverage", leverage);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/leverage", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -330,9 +330,9 @@ namespace WhiteBit.Net.Clients.V4Api
         //#region Get Trading Fee
 
         ///// <inheritdoc />
-        //public async Task<WebCallResult<WhiteBitTradingFee>> GetTradingFeeAsync(string symbol, CancellationToken ct = default)
+        //public async Task<HttpResult<WhiteBitTradingFee>> GetTradingFeeAsync(string symbol, CancellationToken ct = default)
         //{
-        //    var parameters = new ParameterCollection();
+        //    var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
         //    parameters.Add("market", symbol);
         //    var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/market/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
         //    return await _baseClient.SendAsync<WhiteBitTradingFee>(request, parameters, null, ct).ConfigureAwait(false);
@@ -343,7 +343,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Trading Fees
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitTradingFees>> GetTradingFeesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitTradingFees>> GetTradingFeesAsync(CancellationToken ct = default)
         {
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/market/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             return await _baseClient.SendAsync<WhiteBitTradingFees>(request, null, ct).ConfigureAwait(false);
@@ -354,9 +354,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Hedge Mode
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitHedgeMode>> GetHedgeModeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitHedgeMode>> GetHedgeModeAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/hedge-mode", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitHedgeMode>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -367,9 +367,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Set Hedge Mode
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitHedgeMode>> SetHedgeModeAsync(bool enableHedgeMode, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitHedgeMode>> SetHedgeModeAsync(bool enableHedgeMode, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("hedgeMode", enableHedgeMode);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/hedge-mode/update", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitHedgeMode>(request, parameters, ct).ConfigureAwait(false);
@@ -379,11 +379,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
 
-        internal async Task<WebCallResult<string>> GetWebsocketTokenAsync(CancellationToken ct = default)
+        internal async Task<HttpResult<string>> GetWebsocketTokenAsync(CancellationToken ct = default)
         {
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/profile/websocket_token", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitToken>(request, null, ct).ConfigureAwait(false);
-            return result.As<string>(result.Data?.Token);
+            return HttpResult.Ok(result, result.Data?.Token);
         }
     }
 }

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiAccount.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiAccount.cs
@@ -175,7 +175,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitDepositWithdrawals>> GetDepositWithdrawalHistoryAsync(TransactionType? type = null, string? asset = null, string? address = null, string? memo = null, string? addresses = null, string? uniqueId = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            parameters.AddAsInt("transactionMethod", type);
+            parameters.Add("transactionMethod", type, EnumSerialization.Number);
             parameters.Add("ticker", asset);
             parameters.Add("address", address);
             parameters.Add("memo", memo);

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCodes.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCodes.cs
@@ -30,7 +30,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("amount", quantity);
             parameters.Add("passphrase", passphrase);
             parameters.Add("description", description);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/codes", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/codes", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCode>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -46,7 +46,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("code", code);
             parameters.Add("passphrase", passphrase);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/codes/apply", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/codes/apply", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCodeResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -62,7 +62,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/main-account/codes/my", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/main-account/codes/my", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitGeneratedCodes>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -78,7 +78,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/codes/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/main-account/codes/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitGeneratedCodes>(request, parameters, ct).ConfigureAwait(false);
             return result;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCodes.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCodes.cs
@@ -23,13 +23,13 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Create Code
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitCode>> CreateCodeAsync(string asset, decimal quantity, string? passphrase = null, string? description = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitCode>> CreateCodeAsync(string asset, decimal quantity, string? passphrase = null, string? description = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("ticker", asset);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptional("passphrase", passphrase);
-            parameters.AddOptional("description", description);
+            parameters.Add("amount", quantity);
+            parameters.Add("passphrase", passphrase);
+            parameters.Add("description", description);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/codes", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCode>(request, parameters, ct).ConfigureAwait(false);
@@ -41,11 +41,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Apply Code
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitCodeResult>> ApplyCodeAsync(string code, string? passphrase = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitCodeResult>> ApplyCodeAsync(string code, string? passphrase = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("code", code);
-            parameters.AddOptional("passphrase", passphrase);
+            parameters.Add("passphrase", passphrase);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/codes/apply", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCodeResult>(request, parameters, ct).ConfigureAwait(false);
@@ -57,11 +57,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Created Codes
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitGeneratedCodes>> GetCreatedCodesAsync(int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitGeneratedCodes>> GetCreatedCodesAsync(int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/main-account/codes/my", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitGeneratedCodes>(request, parameters, ct).ConfigureAwait(false);
@@ -73,11 +73,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Code History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitGeneratedCodes>> GetCodeHistoryAsync(int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitGeneratedCodes>> GetCodeHistoryAsync(int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/main-account/codes/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitGeneratedCodes>(request, parameters, ct).ConfigureAwait(false);

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCollateralTrading.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCollateralTrading.cs
@@ -74,7 +74,7 @@ namespace WhiteBit.Net.Clients.V4Api
             else
                 throw new ArgumentException("Unknown path for order type");
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, path, WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, path, WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCollateralOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -89,7 +89,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/positions/open", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/positions/open", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitPosition[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -109,7 +109,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("endDate", endTime);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/positions/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/collateral-account/positions/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitPositionHistory[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -126,7 +126,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("market", symbol);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/conditional-orders", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/conditional-orders", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConditionalOrdersResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -159,7 +159,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("clientOrderId", clientOrderId);
             parameters.Add("positionSide", positionSide);
             parameters.Add("reduceOnly", reduceOnly);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/collateral/oco", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/collateral/oco", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitOcoOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -174,7 +174,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
             parameters.Add("orderId", orderId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/oco-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/oco-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOcoOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -190,7 +190,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
             parameters.Add("id", orderId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/conditional-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/conditional-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -206,7 +206,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
             parameters.Add("otoId", orderId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/oto-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/oto-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCollateralTrading.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiCollateralTrading.cs
@@ -28,7 +28,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Place Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitCollateralOrder>> PlaceOrderAsync(
+        public async Task<HttpResult<WhiteBitCollateralOrder>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             NewOrderType type,
@@ -46,21 +46,21 @@ namespace WhiteBit.Net.Clients.V4Api
             bool? reduceOnly = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            parameters.AddEnum("side", side);
-            parameters.AddOptionalString("amount", quantity);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptional("clientOrderId", clientOrderId);
-            parameters.AddOptional("postOnly", postOnly);
-            parameters.AddOptional("ioc", immediateOrCancel);
-            parameters.AddOptional("bboRole", bboRole);
-            parameters.AddOptionalString("activation_price", triggerPrice);
-            parameters.AddOptionalString("stopLoss", stopLossPrice);
-            parameters.AddOptionalString("takeProfit", takeProfitPrice);
-            parameters.AddOptionalEnum("stp", stpMode);
-            parameters.AddOptionalEnum("positionSide", positionSide);
-            parameters.AddOptional("reduceOnly", reduceOnly);
+            parameters.Add("side", side);
+            parameters.Add("amount", quantity);
+            parameters.Add("price", price);
+            parameters.Add("clientOrderId", clientOrderId);
+            parameters.Add("postOnly", postOnly);
+            parameters.Add("ioc", immediateOrCancel);
+            parameters.Add("bboRole", bboRole);
+            parameters.Add("activation_price", triggerPrice);
+            parameters.Add("stopLoss", stopLossPrice);
+            parameters.Add("takeProfit", takeProfitPrice);
+            parameters.Add("stp", stpMode);
+            parameters.Add("positionSide", positionSide);
+            parameters.Add("reduceOnly", reduceOnly);
 
             string path;
             if (type == NewOrderType.Limit)
@@ -85,10 +85,10 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Open Positions
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitPosition[]>> GetOpenPositionsAsync(string? symbol = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitPosition[]>> GetOpenPositionsAsync(string? symbol = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/positions/open", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitPosition[]>(request, parameters, ct).ConfigureAwait(false);
@@ -100,15 +100,15 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Position History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitPositionHistory[]>> GetPositionHistoryAsync(string? symbol = null, long? positionId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitPositionHistory[]>> GetPositionHistoryAsync(string? symbol = null, long? positionId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("positionId", positionId);
-            parameters.AddOptionalMilliseconds("startDate", startTime);
-            parameters.AddOptionalMilliseconds("endDate", endTime);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("positionId", positionId);
+            parameters.Add("startDate", startTime);
+            parameters.Add("endDate", endTime);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/collateral-account/positions/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitPositionHistory[]>(request, parameters, ct).ConfigureAwait(false);
@@ -120,12 +120,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Open Conditional Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitConditionalOrdersResult>> GetOpenConditionalOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitConditionalOrdersResult>> GetOpenConditionalOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/conditional-orders", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConditionalOrdersResult>(request, parameters, ct).ConfigureAwait(false);
@@ -137,7 +137,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Place Oco Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOcoOrder>> PlaceOcoOrderAsync(
+        public async Task<HttpResult<WhiteBitOcoOrder>> PlaceOcoOrderAsync(
             string symbol,
             OrderSide orderSide,
             decimal quantity,
@@ -149,16 +149,16 @@ namespace WhiteBit.Net.Clients.V4Api
             bool? reduceOnly = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            parameters.AddEnum("side", orderSide);
-            parameters.AddString("amount", quantity);
-            parameters.AddString("price", price);
-            parameters.AddString("activation_price", triggerPrice);
-            parameters.AddString("stop_limit_price", stopLimitPrice);
-            parameters.AddOptional("clientOrderId", clientOrderId);
-            parameters.AddOptionalEnum("positionSide", positionSide);
-            parameters.AddOptional("reduceOnly", reduceOnly);
+            parameters.Add("side", orderSide);
+            parameters.Add("amount", quantity);
+            parameters.Add("price", price);
+            parameters.Add("activation_price", triggerPrice);
+            parameters.Add("stop_limit_price", stopLimitPrice);
+            parameters.Add("clientOrderId", clientOrderId);
+            parameters.Add("positionSide", positionSide);
+            parameters.Add("reduceOnly", reduceOnly);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/collateral/oco", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var result = await _baseClient.SendAsync<WhiteBitOcoOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -169,9 +169,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Cancel Oco Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOcoOrder>> CancelOcoOrderAsync(string symbol, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitOcoOrder>> CancelOcoOrderAsync(string symbol, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
             parameters.Add("orderId", orderId);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/oco-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
@@ -185,9 +185,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Cancel Conditional Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelConditionalOrderAsync(string symbol, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult> CancelConditionalOrderAsync(string symbol, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
             parameters.Add("id", orderId);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/conditional-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
@@ -201,9 +201,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Cancel OTO Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelOTOOrderAsync(string symbol, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult> CancelOTOOrderAsync(string symbol, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
             parameters.Add("otoId", orderId);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/oto-cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
@@ -58,7 +58,7 @@ namespace WhiteBit.Net.Clients.V4Api
         /// <inheritdoc />
         public async Task<HttpResult<WhiteBitConvertHistory>> GetConvertHistoryAsync(string? fromAsset = null, string? toAsset = null, string? quoteId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("fromTicker", fromAsset);
             parameters.Add("toTicker", toAsset);
             parameters.Add("quoteId", quoteId);
@@ -66,7 +66,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("to", endTime);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConvertHistory>(request, parameters, ct).ConfigureAwait(false);
             return result;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
@@ -23,12 +23,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Convert Estimate
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitConvertEstimate>> GetConvertEstimateAsync(string fromAsset, string toAsset, decimal quantity, string fromOrToQuantity, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitConvertEstimate>> GetConvertEstimateAsync(string fromAsset, string toAsset, decimal quantity, string fromOrToQuantity, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("from", fromAsset);
             parameters.Add("to", toAsset);
-            parameters.AddString("amount", quantity);
+            parameters.Add("amount", quantity);
             parameters.Add("direction", fromOrToQuantity);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/estimate", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -41,9 +41,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Confirm Convert
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitConvertResult>> ConfirmConvertAsync(string estimateId, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitConvertResult>> ConfirmConvertAsync(string estimateId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("quoteId", estimateId);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/confirm", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -56,16 +56,16 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Convert History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitConvertHistory>> GetConvertHistoryAsync(string? fromAsset = null, string? toAsset = null, string? quoteId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitConvertHistory>> GetConvertHistoryAsync(string? fromAsset = null, string? toAsset = null, string? quoteId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("fromTicker", fromAsset);
-            parameters.AddOptional("toTicker", toAsset);
-            parameters.AddOptional("quoteId", quoteId);
-            parameters.AddOptionalMillisecondsString("from", startTime);
-            parameters.AddOptionalMillisecondsString("to", endTime);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("fromTicker", fromAsset);
+            parameters.Add("toTicker", toAsset);
+            parameters.Add("quoteId", quoteId);
+            parameters.Add("from", startTime);
+            parameters.Add("to", endTime);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConvertHistory>(request, parameters, ct).ConfigureAwait(false);

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
@@ -30,7 +30,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("to", toAsset);
             parameters.Add("amount", quantity);
             parameters.Add("direction", fromOrToQuantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/estimate", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/convert/estimate", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConvertEstimate>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -45,7 +45,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("quoteId", estimateId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/confirm", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/convert/confirm", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConvertResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -66,7 +66,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("to", endTime);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitConvertHistory>(request, parameters, ct).ConfigureAwait(false);
             return result;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiExchangeData.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiExchangeData.cs
@@ -28,12 +28,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Server Time
 
         /// <inheritdoc />
-        public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/time", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitTime>(request, null, ct).ConfigureAwait(false);
-            return result.As(result.Data?.Timestamp ?? default);
+            return HttpResult.Ok(result, result.Data?.Timestamp ?? default);
         }
 
         #endregion
@@ -41,9 +41,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitSymbol[]>> GetSymbolsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitSymbol[]>> GetSymbolsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/markets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSymbol[]>(request, parameters, ct).ConfigureAwait(false);
@@ -55,9 +55,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get System Status
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitSystemStatus>> GetSystemStatusAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitSystemStatus>> GetSystemStatusAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/platform/status", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSystemStatus>(request, parameters, ct).ConfigureAwait(false);
@@ -69,19 +69,19 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Tickers
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitTicker[]>> GetTickersAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitTicker[]>> GetTickersAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/ticker", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitTicker>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<WhiteBitTicker[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitTicker[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Symbol = item.Key;
 
-            return result.As<WhiteBitTicker[]>(result.Data.Select(x => x.Value).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => x.Value).ToArray());
         }
 
         #endregion
@@ -89,19 +89,19 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Assets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitAsset[]>> GetAssetsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitAsset[]>> GetAssetsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/assets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitAsset>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<WhiteBitAsset[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitAsset[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return result.As<WhiteBitAsset[]>(result.Data?.Values.ToArray());
+            return HttpResult.Ok(result, result.Data?.Values.ToArray());
         }
 
         #endregion
@@ -109,11 +109,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Order Book
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int? limit = null, int? mergeLevel = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int? limit = null, int? mergeLevel = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("level", mergeLevel);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("limit", limit);
+            parameters.Add("level", mergeLevel);
             var request = _definitions.GetOrCreate(HttpMethod.Get, $"/api/v4/public/orderbook/{symbol}", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(600, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrderBook>(request, parameters, ct).ConfigureAwait(false);
@@ -125,10 +125,10 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Recent Trades
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitTrade[]>> GetRecentTradesAsync(string symbol, OrderSide? side = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitTrade[]>> GetRecentTradesAsync(string symbol, OrderSide? side = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalEnum("type", side);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("type", side);
             var request = _definitions.GetOrCreate(HttpMethod.Get, $"/api/v4/public/trades/{symbol}", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitTrade[]>(request, parameters, ct).ConfigureAwait(false);
@@ -140,9 +140,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Deposit Withdrawal Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitDepositWithdraw>> GetDepositWithdrawalInfoAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitDepositWithdraw>> GetDepositWithdrawalInfoAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositWithdraw>(request, parameters, ct).ConfigureAwait(false);
@@ -154,13 +154,13 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Colleteral Symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<string[]>> GetCollateralSymbolsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<string[]>> GetCollateralSymbolsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/collateral/markets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitResponse<string[]>>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<string[]>(result.Data?.Result);
+            return HttpResult.Ok(result, result.Data?.Result);
         }
 
         #endregion
@@ -168,13 +168,13 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Futures Symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitFuturesSymbol[]>> GetFuturesSymbolsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitFuturesSymbol[]>> GetFuturesSymbolsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/futures", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitResponse<WhiteBitFuturesSymbol[]>>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<WhiteBitFuturesSymbol[]>(result.Data?.Result);
+            return HttpResult.Ok(result, result.Data?.Result);
         }
 
         #endregion
@@ -182,7 +182,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Funding History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitFundingHistory[]>> GetFundingHistoryAsync(
+        public async Task<HttpResult<WhiteBitFundingHistory[]>> GetFundingHistoryAsync(
             string symbol,
             DateTime? startTime = null,
             DateTime? endTime = null,
@@ -190,11 +190,11 @@ namespace WhiteBit.Net.Clients.V4Api
             int? offset = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalSeconds("startDate", startTime);
-            parameters.AddOptionalSeconds("endDate", endTime);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("startDate", startTime);
+            parameters.Add("endDate", endTime);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/funding-history/" + symbol, WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<WhiteBitFundingHistory[]>(request, parameters, ct).ConfigureAwait(false);

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiExchangeData.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiExchangeData.cs
@@ -30,7 +30,7 @@ namespace WhiteBit.Net.Clients.V4Api
         /// <inheritdoc />
         public async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/time", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/time", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitTime>(request, null, ct).ConfigureAwait(false);
             return HttpResult.Ok(result, result.Data?.Timestamp ?? default);
@@ -44,7 +44,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitSymbol[]>> GetSymbolsAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/markets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/markets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSymbol[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -58,7 +58,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitSystemStatus>> GetSystemStatusAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/platform/status", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/platform/status", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSystemStatus>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -72,7 +72,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitTicker[]>> GetTickersAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/ticker", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/ticker", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitTicker>>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
@@ -92,7 +92,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitAsset[]>> GetAssetsAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/assets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/assets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitAsset>>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
@@ -101,7 +101,7 @@ namespace WhiteBit.Net.Clients.V4Api
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return HttpResult.Ok(result, result.Data?.Values.ToArray());
+            return HttpResult.Ok(result, result.Data.Values.ToArray());
         }
 
         #endregion
@@ -114,7 +114,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("limit", limit);
             parameters.Add("level", mergeLevel);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"/api/v4/public/orderbook/{symbol}", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, $"/api/v4/public/orderbook/{symbol}", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(600, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrderBook>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -129,7 +129,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("type", side);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"/api/v4/public/trades/{symbol}", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, $"/api/v4/public/trades/{symbol}", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitTrade[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -143,7 +143,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitDepositWithdraw>> GetDepositWithdrawalInfoAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/fee", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitDepositWithdraw>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -157,10 +157,13 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<string[]>> GetCollateralSymbolsAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/collateral/markets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/collateral/markets", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitResponse<string[]>>(request, parameters, ct).ConfigureAwait(false);
-            return HttpResult.Ok(result, result.Data?.Result);
+            if (!result.Success)
+                return HttpResult.Fail<string[]>(result);
+
+            return HttpResult.Ok(result, result.Data.Result!);
         }
 
         #endregion
@@ -171,10 +174,13 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitFuturesSymbol[]>> GetFuturesSymbolsAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/futures", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/futures", WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitResponse<WhiteBitFuturesSymbol[]>>(request, parameters, ct).ConfigureAwait(false);
-            return HttpResult.Ok(result, result.Data?.Result);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitFuturesSymbol[]>(result);
+
+            return HttpResult.Ok(result, result.Data.Result!);
         }
 
         #endregion
@@ -195,7 +201,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("endDate", endTime);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v4/public/funding-history/" + symbol, WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v4/public/funding-history/" + symbol, WhiteBitExchange.RateLimiter.WhiteBit, 1, false,
                 limitGuard: new SingleLimitGuard(2000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<WhiteBitFundingHistory[]>(request, parameters, ct).ConfigureAwait(false);
         }

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
@@ -25,7 +25,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(WhiteBitExchange.Metadata, this);
 
         #region Spot Symbol client
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchange, false);
@@ -50,20 +50,20 @@ namespace WhiteBit.Net.Clients.V4Api
                 PriceDecimals = s.QuoteAssetPrecision
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, response.Data!);
             return response;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
@@ -71,26 +71,26 @@ namespace WhiteBit.Net.Clients.V4Api
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -111,7 +111,14 @@ namespace WhiteBit.Net.Clients.V4Api
             if (ticker == null)
                 return HttpResult.Fail<SharedSpotTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, null, null, ticker.BaseVolume, ticker.ChangePercentage)
+            return HttpResult.Ok(result, new SharedSpotTicker(
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, ticker.Symbol), 
+                ticker.Symbol,
+                ticker.LastPrice,
+                null, 
+                null, 
+                ticker.BaseVolume, 
+                ticker.ChangePercentage)
             {
                 QuoteVolume = ticker.QuoteVolume
             });
@@ -129,7 +136,15 @@ namespace WhiteBit.Net.Clients.V4Api
                 return HttpResult.Fail<SharedSpotTicker[]>(result);
 
             var data = result.Data.Where(x => !x.Symbol.EndsWith("_PERP"));
-            return HttpResult.Ok(result, data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), x.Symbol, x.LastPrice, null, null, x.BaseVolume, x.ChangePercentage)
+            return HttpResult.Ok(result, data.Select(x => 
+            new SharedSpotTicker(
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
+                x.Symbol, 
+                x.LastPrice,
+                null,
+                null,
+                x.BaseVolume,
+                x.ChangePercentage)
             {
                 QuoteVolume = x.QuoteVolume
             }).ToArray());
@@ -151,7 +166,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
             return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, resultTicker.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.Asks[0].Price,
                 resultTicker.Data.Asks[0].Quantity,
@@ -548,7 +563,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (openOrder != null)
             {
                 return HttpResult.Ok(openOrders, new SharedSpotOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, openOrder.Symbol), 
+                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, openOrder.Symbol), 
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
                     ParseOrderType(openOrder.OrderType, openOrder.PostOnly),
@@ -581,7 +596,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 var status = closedOrder.Status == OrderStatus.Canceled ? SharedOrderStatus.Canceled : SharedOrderStatus.Filled;
 
                 return HttpResult.Ok(closeOrders, new SharedSpotOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, closedOrder.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, closedOrder.Symbol),
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
                     ParseOrderType(closedOrder.OrderType, closedOrder.PostOnly),
@@ -618,7 +633,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var data = orders.Data.Where(x => !x.Symbol.EndsWith("_PERP"));
 
             return HttpResult.Ok(orders, data.Select(x => new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
                 ParseOrderType(x.OrderType, x.PostOnly),
@@ -675,7 +690,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 TimeSpan.FromDays(180));
 
             var data = result.Data.Where(x => !x.Key.EndsWith("_PERP")).SelectMany(xk => xk.Value.Select(x => new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                 xk.Key,
                 x.OrderId.ToString(),
                 ParseOrderType(x.OrderType, x.PostOnly),
@@ -713,7 +728,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 return HttpResult.Fail<SharedUserTrade[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
                 x.Id.ToString(),
@@ -765,7 +780,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                        .Select(y => new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, y.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, y.Symbol),
                             y.Symbol,
                             y.OrderId.ToString(),
                             y.Id.ToString(),
@@ -851,20 +866,20 @@ namespace WhiteBit.Net.Clients.V4Api
                     };
                 }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, null, response.Data!);
             return response;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
@@ -872,26 +887,26 @@ namespace WhiteBit.Net.Clients.V4Api
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, EnvironmentName, null, symbolName));
         }
 
         #endregion
@@ -914,7 +929,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (ticker == null)
                 return HttpResult.Fail<SharedFuturesTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return HttpResult.Ok(resultTicker, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.BaseVolume, null)
+            return HttpResult.Ok(resultTicker, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.BaseVolume, null)
             {
                 IndexPrice = ticker.IndexPrice,
                 FundingRate = ticker.FundingRate,
@@ -935,7 +950,13 @@ namespace WhiteBit.Net.Clients.V4Api
 
             return HttpResult.Ok(resultTickers, resultTickers.Data.Select(x =>
             {
-                return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.BaseVolume, null)
+                return new SharedFuturesTicker(
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol),
+                    x.Symbol, 
+                    x.LastPrice,
+                    x.HighPrice,
+                    x.LowPrice,
+                    x.BaseVolume, null)
                 {
                     IndexPrice = x.IndexPrice,
                     FundingRate = x.FundingRate,
@@ -1043,7 +1064,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedPositionHistory(
-                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                                 x.Symbol,
                                 x.Quantity >= 0 ? SharedPositionSide.Long : SharedPositionSide.Short,
                                 x.BasePrice,
@@ -1118,7 +1139,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (openOrder != null)
             {
                 return HttpResult.Ok(openOrders, new SharedFuturesOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, openOrder.Symbol), 
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, openOrder.Symbol), 
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
                     ParseOrderType(openOrder.OrderType, openOrder.PostOnly),
@@ -1156,7 +1177,7 @@ namespace WhiteBit.Net.Clients.V4Api
                     : SharedOrderStatus.Filled;
 
                 return HttpResult.Ok(closeOrders, new SharedFuturesOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, closedOrder.Symbol), 
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, closedOrder.Symbol), 
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
                     ParseOrderType(closedOrder.OrderType, closedOrder.PostOnly),
@@ -1196,7 +1217,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var data = orders.Data.Where(x => x.Symbol.EndsWith("_PERP"));
 
             return HttpResult.Ok<SharedFuturesOrder[]>(orders, [.. data.Select(x => new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
                 ParseOrderType(x.OrderType, x.PostOnly),
@@ -1256,7 +1277,7 @@ namespace WhiteBit.Net.Clients.V4Api
                TimeSpan.FromDays(180));
 
             var data = result.Data.Where(x => x.Key.EndsWith("_PERP")).SelectMany(xk => xk.Value.Select(x => new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, xk.Key), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, xk.Key), 
                 xk.Key,
                 x.OrderId.ToString(),
                 ParseOrderType(x.OrderType, x.PostOnly),
@@ -1299,7 +1320,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 return HttpResult.Fail<SharedUserTrade[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                 request.Symbol!.GetSymbol(FormatSymbol),
                 x.OrderId.ToString(),
                 x.Id.ToString(),
@@ -1352,7 +1373,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                        .Select(y => 
                            new SharedUserTrade(
-                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, y.Symbol), 
+                                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, y.Symbol), 
                                 y.Symbol,
                                 y.OrderId.ToString(),
                                 y.Id.ToString(),
@@ -1400,7 +1421,11 @@ namespace WhiteBit.Net.Clients.V4Api
             var data = result.Data;
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol.TradingMode } : new[] { request.TradingMode!.Value };
             return HttpResult.Ok(result, data.Select(x =>
-            new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.Quantity), x.UpdateTime)
+            new SharedPosition(
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol),
+                x.Symbol,
+                Math.Abs(x.Quantity),
+                x.UpdateTime)
             {
                 UnrealizedPnl = x.Pnl,
                 LiquidationPrice = x.LiquidationPrice == 0 ? null : x.LiquidationPrice,
@@ -1513,7 +1538,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (openOrder != null)
             {
                 return HttpResult.Ok(openOrders, new SharedSpotTriggerOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, openOrder.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, openOrder.Symbol),
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
                     ParseOrderType(openOrder.OrderType, openOrder.PostOnly),
@@ -1544,7 +1569,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
                 var closedOrder = closeOrders.Data.Single().Value.Single();
                 return HttpResult.Ok(closeOrders, new SharedSpotTriggerOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, closedOrder.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, closedOrder.Symbol),
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
                     ParseOrderType(closedOrder.OrderType, closedOrder.PostOnly),
@@ -1645,7 +1670,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (openOrder != null)
             {
                 return HttpResult.Ok(openOrders, new SharedFuturesTriggerOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, openOrder.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, openOrder.Symbol),
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
                     ParseOrderType(openOrder.OrderType, openOrder.PostOnly),
@@ -1678,7 +1703,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 var closedOrder = closeOrders.Data.Single().Value.Single();
                 
                 return HttpResult.Ok(closeOrders, new SharedFuturesTriggerOrder(
-                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, closedOrder.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, closedOrder.Symbol),
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
                     ParseOrderType(closedOrder.OrderType, closedOrder.PostOnly),

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
@@ -426,7 +426,13 @@ namespace WhiteBit.Net.Clients.V4Api
 
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Records, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                        .Select(x => 
-                           new SharedWithdrawal(x.Asset, x.Address, x.Quantity, x.TransactionStatus == Enums.TransactionStatus.Success, x.CreateTime)
+                           new SharedWithdrawal(
+                               x.Asset,
+                               x.Address,
+                               x.Quantity,
+                               x.TransactionStatus == Enums.TransactionStatus.Success,
+                               x.CreateTime,
+                               GetWithdrawalStatus(x))
                            {
                                Confirmations = x.Confirmations?.Actual,
                                Network = x.Network,
@@ -438,6 +444,23 @@ namespace WhiteBit.Net.Clients.V4Api
                     .ToArray(), nextPageRequest);
         }
 
+        private SharedTransferStatus GetWithdrawalStatus(WhiteBitDepositWithdrawal x)
+        {
+            if (x.TransactionStatus == TransactionStatus.Canceled || x.TransactionStatus == TransactionStatus.UnconfirmedByUser)
+                return SharedTransferStatus.Failed;
+
+            if (x.TransactionStatus == TransactionStatus.Success || x.TransactionStatus == TransactionStatus.PartialSuccess)
+                return SharedTransferStatus.Completed;
+
+            if (x.TransactionStatus == TransactionStatus.AwaitingVerification
+                || x.TransactionStatus == TransactionStatus.ConfirmationInProgress
+                || x.TransactionStatus == TransactionStatus.Frozen
+                || x.TransactionStatus == TransactionStatus.Pending
+                || x.TransactionStatus == TransactionStatus.Uncredited)
+                return SharedTransferStatus.InProgress;
+
+            return SharedTransferStatus.Unknown;
+        }
         #endregion
 
         #region Withdraw client

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
@@ -241,7 +241,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 if (!result.Success)
                     return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => 
+                    new SharedBalance(TradingMode.Spot, x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
             }
             else if(request.AccountType == SharedAccountType.Funding)
             {
@@ -249,7 +250,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 if (!result.Success)
                     return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.MainBalance, x.MainBalance)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => 
+                    new SharedBalance([], x.Asset, x.MainBalance, x.MainBalance)).ToArray());
             }
             else
             {
@@ -257,7 +259,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 if (!result.Success)
                     return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Key, x.Value, x.Value)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x =>
+                    new SharedBalance(SupportedFuturesModes, x.Key, x.Value, x.Value)).ToArray());
             }
         }
 

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
@@ -16,10 +16,11 @@ namespace WhiteBit.Net.Clients.V4Api
 {
     internal partial class WhiteBitRestClientV4Api : IWhiteBitRestClientV4ApiShared
     {
+        private const string _exchange = "WhiteBit";
         private const string _topicSpotId = "WhiteBitSpot";
         private const string _topicFuturesId = "WhiteBitFutures";
 
-        public string Exchange => "WhiteBit";
+        public string Exchange => _exchange;
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear };
         public TradingMode[] SupportedFuturesModes => new[] { TradingMode.PerpetualLinear };
@@ -28,22 +29,21 @@ namespace WhiteBit.Net.Clients.V4Api
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
 
         #region Spot Symbol client
-        EndpointOptions<GetSymbolsRequest> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
+        EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient>(_exchange, false);
 
-        async Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotSymbolRestClient)this).GetSpotSymbolsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
             var data = result.Data.Where(x => x.SymbolType == Enums.SymbolType.Spot);
 
-            var response = result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, TradingMode.Spot, 
-                data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, s.TradingEnabled)
+            var response = HttpResult.Ok(result, data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, s.TradingEnabled)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinOrderValue,
@@ -55,19 +55,19 @@ namespace WhiteBit.Net.Clients.V4Api
             return response;
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
@@ -75,62 +75,62 @@ namespace WhiteBit.Net.Clients.V4Api
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
         }
         #endregion
 
         #region Ticker client
 
-        GetTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchange);
+        async Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker>(Exchange, validationError);
 
             var result = await ExchangeData.GetTickersAsync(ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker>(result);
 
             var ticker = result.Data.SingleOrDefault(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             if (ticker == null)
-                return result.AsExchangeError<SharedSpotTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedSpotTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, null, null, ticker.BaseVolume, ticker.ChangePercentage)
+            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, null, null, ticker.BaseVolume, ticker.ChangePercentage)
             {
                 QuoteVolume = ticker.QuoteVolume
             });
         }
 
-        GetTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchange);
+        async Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickersOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker[]>(result);
 
             var data = result.Data.Where(x => !x.Symbol.EndsWith("_PERP"));
-            return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, TradingMode.Spot, data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), x.Symbol, x.LastPrice, null, null, x.BaseVolume, x.ChangePercentage)
+            return HttpResult.Ok(result, data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), x.Symbol, x.LastPrice, null, null, x.BaseVolume, x.ChangePercentage)
             {
                 QuoteVolume = x.QuoteVolume
             }).ToArray());
@@ -140,18 +140,18 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchange, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetOrderBookAsync(request.Symbol!.GetSymbol(FormatSymbol), 1, ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedBookTicker(
+            return HttpResult.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.Asks[0].Price,
@@ -163,28 +163,28 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region Recent Trades client
-        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(100, false);
+        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(_exchange, 100, false);
 
-        async Task<ExchangeWebResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IRecentTradeRestClient)this).GetRecentTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetRecentTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedTrade[]>(Exchange, validationError);
 
             // Get data
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetRecentTradesAsync(
                 symbol,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedTrade[]>(result);
 
             IEnumerable<WhiteBitTrade> data = result.Data;
             if (request.Limit != null)
                 data = data.Take(request.Limit.Value);
 
             // Return
-            return result.AsExchangeResult<SharedTrade[]>(Exchange, request.Symbol.TradingMode, data.Select(x => 
+            return HttpResult.Ok(result, data.Select(x =>
                 new SharedTrade(request.Symbol, symbol, x.BaseVolume, x.Price, x.Timestamp)
                 {
                     Side = x.Side == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
@@ -193,76 +193,76 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(1, 100, false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchange, 1, 100, false);
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 limit: request.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOrderBook>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedOrderBook(result.Data.Asks, result.Data.Bids));
+            return HttpResult.Ok(result, new SharedOrderBook(result.Data.Asks, result.Data.Bids));
         }
 
         #endregion
 
         #region Balance Client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(AccountTypeFilter.Funding, AccountTypeFilter.Spot, AccountTypeFilter.Futures);
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchange, AccountTypeFilter.Funding, AccountTypeFilter.Spot, AccountTypeFilter.Futures);
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
             if (request.AccountType == null || request.AccountType == SharedAccountType.Spot)
             {
                 var result = await Account.GetSpotBalancesAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedBalance[]>(result);
 
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, TradingMode.Spot, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
             }
             else if(request.AccountType == SharedAccountType.Funding)
             {
                 var result = await Account.GetMainBalancesAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedBalance[]>(result);
 
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, SupportedFuturesModes, result.Data.Select(x => new SharedBalance(x.Asset, x.MainBalance, x.MainBalance)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.MainBalance, x.MainBalance)).ToArray());
             }
             else
             {
                 var result = await Account.GetCollateralBalancesAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedBalance[]>(result);
 
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, SupportedFuturesModes, result.Data.Select(x => new SharedBalance(x.Key, x.Value, x.Value)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Key, x.Value, x.Value)).ToArray());
             }
         }
 
         #endregion
 
         #region Asset client
-        EndpointOptions<GetAssetsRequest> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest>(true);
+        EndpointOptions<GetAssetsRequest, IAssetsRestClient> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest, IAssetsRestClient>(_exchange, true);
 
-        async Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset[]>(Exchange, validationError);
 
             var assets = await ExchangeData.GetAssetsAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset[]>(Exchange, null, default);
+            if (!assets.Success)
+                return HttpResult.Fail<SharedAsset[]>(assets);
 
-            return assets.AsExchangeResult<SharedAsset[]>(Exchange, TradingMode.Spot, assets.Data.Select(x => 
+            return HttpResult.Ok(assets, assets.Data.Select(x =>
             {
                 var networks = x.Networks.Withdraws.Intersect(x.Networks.Deposits);
                 return new SharedAsset(x.Asset)
@@ -277,23 +277,23 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        EndpointOptions<GetAssetRequest> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest>(false);
-        async Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        EndpointOptions<GetAssetRequest, IAssetsRestClient> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest, IAssetsRestClient>(_exchange, false);
+        async Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset>(Exchange, validationError);
 
             var assets = await ExchangeData.GetAssetsAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset>(Exchange, null, default);
+            if (!assets.Success)
+                return HttpResult.Fail<SharedAsset>(assets);
 
             var asset = assets.Data.SingleOrDefault(x => x.Asset == request.Asset);
             if (asset == null)
-                return assets.AsExchangeError<SharedAsset>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
+                return HttpResult.Fail<SharedAsset>(assets, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
 
             var networks = asset.Networks.Withdraws.Intersect(asset.Networks.Deposits);
-            return assets.AsExchangeResult(Exchange, TradingMode.Spot, new SharedAsset(asset.Asset)
+            return HttpResult.Ok(assets, new SharedAsset(asset.Asset)
             {
                 FullName = asset.Name,
                 Networks = networks.Select(n => new SharedAssetNetwork(n)
@@ -308,30 +308,30 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Deposit client
 
-        EndpointOptions<GetDepositAddressesRequest> IDepositRestClient.GetDepositAddressesOptions { get; } = new EndpointOptions<GetDepositAddressesRequest>(true);
-        async Task<ExchangeWebResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
+        EndpointOptions<GetDepositAddressesRequest, IDepositRestClient> IDepositRestClient.GetDepositAddressesOptions { get; } = new EndpointOptions<GetDepositAddressesRequest, IDepositRestClient>(_exchange, true);
+        async Task<HttpResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositAddressesOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositAddressesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDepositAddress[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDepositAddress[]>(Exchange, validationError);
 
             var depositAddresses = await Account.GetDepositAddressAsync(request.Asset, request.Network, ct: ct).ConfigureAwait(false);
-            if (!depositAddresses)
-                return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, null, default);
+            if (!depositAddresses.Success)
+                return HttpResult.Fail<SharedDepositAddress[]>(depositAddresses);
 
-            return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, TradingMode.Spot, new[] { new SharedDepositAddress(request.Asset, depositAddresses.Data.Account.Address)
+            return HttpResult.Ok(depositAddresses, new[] { new SharedDepositAddress(request.Asset, depositAddresses.Data.Account.Address)
             {
                 Network = request.Network
             }
             });
         }
 
-        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(false, true, false, 100);
-        async Task<ExchangeWebResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(_exchange, false, true, false, 100);
+        async Task<HttpResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDeposit[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDeposit[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -344,8 +344,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 limit: limit,
                 offset: pageParams.Offset,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedDeposit[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedDeposit[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -355,10 +355,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data.Records, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Records, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                        .Select(x =>
                             new SharedDeposit(
                                 x.Asset,
@@ -397,12 +394,12 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Withdrawal client
 
-        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(false, true, false, 100);
-        async Task<ExchangeWebResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(_exchange, false, true, false, 100);
+        async Task<HttpResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IWithdrawalRestClient)this).GetWithdrawalsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetWithdrawalsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedWithdrawal[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedWithdrawal[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -415,8 +412,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 limit: limit,
                 offset: pageParams.Offset,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedWithdrawal[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedWithdrawal[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -426,10 +423,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data.Records, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Records, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedWithdrawal(x.Asset, x.Address, x.Quantity, x.TransactionStatus == Enums.TransactionStatus.Success, x.CreateTime)
                            {
@@ -447,12 +441,12 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Withdraw client
 
-        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions();
-        async Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchange);
+        async Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
-            var validationError = ((IWithdrawRestClient)this).WithdrawOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.WithdrawOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var id = Guid.NewGuid().ToString();
             // Get data
@@ -465,10 +459,10 @@ namespace WhiteBit.Net.Clients.V4Api
                 network: request.Network,
                 memo: request.AddressTag,
                 ct: ct).ConfigureAwait(false);
-            if (!withdrawal)
-                return withdrawal.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!withdrawal.Success)
+                return HttpResult.Fail<SharedId>(withdrawal);
 
-            return withdrawal.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(id));
+            return HttpResult.Ok(withdrawal, new SharedId(id));
         }
 
         #endregion
@@ -487,19 +481,12 @@ namespace WhiteBit.Net.Clients.V4Api
 
         string ISpotOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(32);
 
-        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions();
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions(_exchange);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).PlaceSpotOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.TradingMode,
-                [TradingMode.Spot],
-                ((ISpotOrderRestClient)this).SpotSupportedOrderTypes,
-                ((ISpotOrderRestClient)this).SpotSupportedTimeInForce,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceSpotOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -513,30 +500,30 @@ namespace WhiteBit.Net.Clients.V4Api
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, [TradingMode.Spot]);
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var openOrders = await Trading.GetOpenOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!openOrders)
-                return openOrders.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!openOrders.Success)
+                return HttpResult.Fail<SharedSpotOrder>(openOrders);
 
             var openOrder = openOrders.Data.SingleOrDefault();
             if (openOrder != null)
             {
-                return openOrders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+                return HttpResult.Ok(openOrders, new SharedSpotOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicSpotId, openOrder.Symbol), 
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
@@ -560,16 +547,16 @@ namespace WhiteBit.Net.Clients.V4Api
             else
             {
                 var closeOrders = await Trading.GetClosedOrdersAsync(request.Symbol.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-                if (!closeOrders)
-                    return closeOrders.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+                if (!closeOrders.Success)
+                    return HttpResult.Fail<SharedSpotOrder>(closeOrders);
 
                 if (!closeOrders.Data.Any())
-                    return closeOrders.AsExchangeError<SharedSpotOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                    return HttpResult.Fail<SharedSpotOrder>(closeOrders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
                 var closedOrder = closeOrders.Data.Single().Value.Single();
                 var status = closedOrder.Status == OrderStatus.Canceled ? SharedOrderStatus.Canceled : SharedOrderStatus.Filled;
 
-                return closeOrders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+                return HttpResult.Ok(closeOrders, new SharedSpotOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicSpotId, closedOrder.Symbol),
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
@@ -592,21 +579,21 @@ namespace WhiteBit.Net.Clients.V4Api
             }
         }
 
-        EndpointOptions<GetOpenOrdersRequest> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetOpenSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, [TradingMode.Spot]);
+            var validationError = SharedClient.GetOpenSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var orders = await Trading.GetOpenOrdersAsync(symbol, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(orders);
 
             var data = orders.Data.Where(x => !x.Symbol.EndsWith("_PERP"));
 
-            return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, TradingMode.Spot, data.Select(x => new SharedSpotOrder(
+            return HttpResult.Ok(orders, data.Select(x => new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -628,15 +615,15 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        GetClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetClosedOrdersOptions(true, false, true, 100)
+        GetSpotClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetSpotClosedOrdersOptions(_exchange, true, false, true, 100)
         {
             MaxAge = TimeSpan.FromDays(180)
         };
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetClosedSpotOrdersOptions.ValidateRequest(Exchange, request, request.TradingMode, [TradingMode.Spot]);
+            var validationError = SharedClient.GetClosedSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -650,8 +637,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 limit: limit,
                 offset: pageParams.Offset,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -684,28 +671,24 @@ namespace WhiteBit.Net.Clients.V4Api
                 IsTriggerOrder = x.TriggerPrice > 0
             }));
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(data, x => x.CreateTime!.Value, request.StartTime, request.EndTime, direction).ToArray(),
-                       nextPageRequest);
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.CreateTime!.Value, request.StartTime, request.EndTime, direction).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, [TradingMode.Spot]);
+            var validationError = SharedClient.GetSpotOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetOrderTradesAsync(orderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(orders);
 
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, TradingMode.Spot, orders.Data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(orders, orders.Data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -722,15 +705,15 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        GetUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetUserTradesOptions(false, true, true, 100)
+        GetSpotUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetSpotUserTradesOptions(_exchange, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(180)
         };
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotUserTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, [TradingMode.Spot]);
+            var validationError = SharedClient.GetSpotUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -744,8 +727,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 offset: pageParams.Offset,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -756,10 +739,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 pageParams,
                 maxAge: TimeSpan.FromDays(180));
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                        .Select(y => new SharedUserTrade(
                             ExchangeSymbolCache.ParseSymbol(_topicSpotId, y.Symbol),
                             y.Symbol,
@@ -777,21 +757,21 @@ namespace WhiteBit.Net.Clients.V4Api
                         }).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, [TradingMode.Spot]);
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(order.Data.OrderId.ToString()));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId.ToString()));
         }
 
         private SharedOrderType ParseOrderType(OrderType type, bool postOnly)
@@ -816,25 +796,27 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Futures Symbol client
 
-        EndpointOptions<GetSymbolsRequest> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
-        async Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient>(_exchange, false);
+        async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesSymbolRestClient)this).GetFuturesSymbolsOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetFuturesSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var symbols = ExchangeData.GetSymbolsAsync(ct);
-            var futuresSymbols = ExchangeData.GetFuturesSymbolsAsync(ct);
-            await Task.WhenAll(symbols, futuresSymbols).ConfigureAwait(false);
-            if (!symbols.Result)
-                return symbols.Result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, null, default);
-            if (!futuresSymbols.Result)
-                return futuresSymbols.Result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, null, default);
+            var symbolsTask = ExchangeData.GetSymbolsAsync(ct);
+            var futuresSymbolsTask = ExchangeData.GetFuturesSymbolsAsync(ct);
+            await Task.WhenAll(symbolsTask, futuresSymbolsTask).ConfigureAwait(false);
 
-            var response = futuresSymbols.Result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, request.TradingMode == null ? SupportedTradingModes : new[] { request.TradingMode.Value },
-                futuresSymbols.Result.Data.Select(s =>
+            var symbols = symbolsTask.Result;
+            var futuresSymbols = futuresSymbolsTask.Result;
+            if (!symbols.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(symbols);
+            if (!futuresSymbols.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(futuresSymbols);
+
+            var response = HttpResult.Ok(futuresSymbols, futuresSymbols.Data.Select(s =>
                 {
-                    var symbol = symbols.Result.Data.SingleOrDefault(x => x.Name == s.Symbol);
+                    var symbol = symbols.Data.SingleOrDefault(x => x.Name == s.Symbol);
                     return new SharedFuturesSymbol(s.ProductType == ProductType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear, s.BaseAsset, s.QuoteAsset, s.Symbol, true)
                     {
                         MinTradeQuantity = symbol?.MinOrderQuantity,
@@ -849,19 +831,19 @@ namespace WhiteBit.Net.Clients.V4Api
             return response;
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
@@ -869,46 +851,46 @@ namespace WhiteBit.Net.Clients.V4Api
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
         }
 
         #endregion
 
         #region Futures Ticker client
 
-        GetTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchange);
+        async Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetFuturesTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetFuturesSymbolsAsync(ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var ticker = resultTicker.Data.SingleOrDefault(x => x.Symbol == symbol);
             if (ticker == null)
-                return resultTicker.AsExchangeError<SharedFuturesTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.BaseVolume, null)
+            return HttpResult.Ok(resultTicker, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.BaseVolume, null)
             {
                 IndexPrice = ticker.IndexPrice,
                 FundingRate = ticker.FundingRate,
@@ -916,18 +898,18 @@ namespace WhiteBit.Net.Clients.V4Api
             });
         }
 
-        GetTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchange);
+        async Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetFuturesTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker[]>(Exchange, validationError);
 
             var resultTickers = await ExchangeData.GetFuturesSymbolsAsync(ct).ConfigureAwait(false);
-            if (!resultTickers)
-                return resultTickers.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
+            if (!resultTickers.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(resultTickers);
 
-            return resultTickers.AsExchangeResult<SharedFuturesTicker[]>(Exchange, request.TradingMode == null ? SupportedTradingModes : new[] { request.TradingMode.Value }, resultTickers.Data.Select(x =>
+            return HttpResult.Ok(resultTickers, resultTickers.Data.Select(x =>
             {
                 return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.BaseVolume, null)
                 {
@@ -943,72 +925,72 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerAccount;
 
-        EndpointOptions<GetLeverageRequest> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest>(true);
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        EndpointOptions<GetLeverageRequest, ILeverageRestClient> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest, ILeverageRestClient>(_exchange, true);
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).GetLeverageOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Account.GetCollateralAccountSummaryAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedLeverage(result.Data.Leverage));
+            return HttpResult.Ok(result, new SharedLeverage(result.Data.Leverage));
         }
 
-        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions();
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions(_exchange);
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).SetLeverageOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.SetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Account.SetAccountLeverageAsync((int)request.Leverage, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
-            return result.AsExchangeResult(Exchange, request.TradingMode, new SharedLeverage(result.Data.Leverage));
+            return HttpResult.Ok(result, new SharedLeverage(result.Data.Leverage));
         }
         #endregion
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest>(true);
-        async Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient>(_exchange, true);
+        async Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
-            var validationError = ((IOpenInterestRestClient)this).GetOpenInterestOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetOpenInterestOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOpenInterest>(Exchange, validationError);
+                return HttpResult.Fail<SharedOpenInterest>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetFuturesSymbolsAsync(ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedOpenInterest>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedOpenInterest>(resultTicker);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var ticker = resultTicker.Data.SingleOrDefault(x => x.Symbol == symbol);
             if (ticker == null)
-                return resultTicker.AsExchangeError<SharedOpenInterest>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedOpenInterest>(resultTicker, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedOpenInterest(ticker.OpenInterest));
+            return HttpResult.Ok(resultTicker, new SharedOpenInterest(ticker.OpenInterest));
         }
 
         #endregion
 
         #region Position History client
 
-        GetPositionHistoryOptions IPositionHistoryRestClient.GetPositionHistoryOptions { get; } = new GetPositionHistoryOptions(false, true, true, 100)
+        GetPositionHistoryOptions IPositionHistoryRestClient.GetPositionHistoryOptions { get; } = new GetPositionHistoryOptions(_exchange, false, true, true, 100)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(GetPositionHistoryRequest.Symbol), typeof(SharedSymbol), "The symbol to get position history for", "ETH_PERP")
             }
         };
-        async Task<ExchangeWebResult<SharedPositionHistory[]>> IPositionHistoryRestClient.GetPositionHistoryAsync(GetPositionHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedPositionHistory[]>> IPositionHistoryRestClient.GetPositionHistoryAsync(GetPositionHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IPositionHistoryRestClient)this).GetPositionHistoryOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetPositionHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPositionHistory[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPositionHistory[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -1023,8 +1005,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 offset: pageParams.Offset,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPositionHistory[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPositionHistory[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -1034,10 +1016,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 request.EndTime ?? DateTime.UtcNow,
                 pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       request.Symbol.TradingMode,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedPositionHistory(
                                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
@@ -1069,19 +1048,12 @@ namespace WhiteBit.Net.Clients.V4Api
 
         string IFuturesOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(32);
 
-        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(_exchange, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).PlaceFuturesOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.TradingMode,
-                SupportedFuturesModes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderTypes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedTimeInForce,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await CollateralTrading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1098,30 +1070,30 @@ namespace WhiteBit.Net.Clients.V4Api
                 reduceOnly: request.ReduceOnly,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var openOrders = await Trading.GetOpenOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!openOrders)
-                return openOrders.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!openOrders.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(openOrders);
 
             var openOrder = openOrders.Data.SingleOrDefault();
             if (openOrder != null)
             {
-                return openOrders.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesOrder(
+                return HttpResult.Ok(openOrders, new SharedFuturesOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicFuturesId, openOrder.Symbol), 
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
@@ -1148,18 +1120,18 @@ namespace WhiteBit.Net.Clients.V4Api
             else
             {
                 var closeOrders = await Trading.GetClosedOrdersAsync(request.Symbol.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-                if (!closeOrders)
-                    return closeOrders.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+                if (!closeOrders.Success)
+                    return HttpResult.Fail<SharedFuturesOrder>(closeOrders);
 
                 if (!closeOrders.Data.Any())
-                    return closeOrders.AsExchangeError<SharedFuturesOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                    return HttpResult.Fail<SharedFuturesOrder>(closeOrders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
                 var closedOrder = closeOrders.Data.Single().Value.Single();
                 var status = closedOrder.Status is OrderStatus.Canceled or OrderStatus.AutoCanceledUserMargin 
                     ? SharedOrderStatus.Canceled 
                     : SharedOrderStatus.Filled;
 
-                return closeOrders.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesOrder(
+                return HttpResult.Ok(closeOrders, new SharedFuturesOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicFuturesId, closedOrder.Symbol), 
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
@@ -1185,21 +1157,21 @@ namespace WhiteBit.Net.Clients.V4Api
             }            
         }
 
-        EndpointOptions<GetOpenOrdersRequest> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetOpenFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetOpenFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var orders = await Trading.GetOpenOrdersAsync(symbol, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
             var data = orders.Data.Where(x => x.Symbol.EndsWith("_PERP"));
 
-            return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, SupportedFuturesModes, [.. data.Select(x => new SharedFuturesOrder(
+            return HttpResult.Ok<SharedFuturesOrder[]>(orders, [.. data.Select(x => new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -1224,15 +1196,15 @@ namespace WhiteBit.Net.Clients.V4Api
             })]);
         }
 
-        GetClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetClosedOrdersOptions(false, true, true, 100)
+        GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchange, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(180)
         };
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetClosedFuturesOrdersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetClosedFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -1246,8 +1218,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 limit: limit,
                 offset: pageParams.Offset,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -1285,28 +1257,24 @@ namespace WhiteBit.Net.Clients.V4Api
                 UpdateTime = x.FillTime ?? x.UpdateTime
             }));
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       request.Symbol.TradingMode,
-                       ExchangeHelpers.ApplyFilter(data, x => x.CreateTime!.Value, request.StartTime, request.EndTime, direction).ToArray(),
-                       nextPageRequest);
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.CreateTime!.Value, request.StartTime, request.EndTime, direction).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetFuturesOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetOrderTradesAsync(orderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(orders);
 
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, request.TradingMode, orders.Data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(orders, orders.Data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
                 request.Symbol!.GetSymbol(FormatSymbol),
                 x.OrderId.ToString(),
@@ -1323,15 +1291,15 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        GetUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetUserTradesOptions(false, true, true, 100)
+        GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchange, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(180)
         };
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesUserTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetFuturesUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -1345,8 +1313,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 offset: pageParams.Offset,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                 () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -1357,10 +1325,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 pageParams,
                 maxAge: TimeSpan.FromDays(180));
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       TradingMode.Spot,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                        .Select(y => 
                            new SharedUserTrade(
                                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, y.Symbol), 
@@ -1380,37 +1345,37 @@ namespace WhiteBit.Net.Clients.V4Api
                        .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(order.Data.OrderId.ToString()));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetPositionsRequest> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest>(true);
-        async Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetPositionsOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.GetPositionsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPosition[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPosition[]>(Exchange, validationError);
 
             var result = await CollateralTrading.GetOpenPositionsAsync(symbol: request.Symbol?.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPosition[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPosition[]>(result);
 
             var data = result.Data;
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol.TradingMode } : new[] { request.TradingMode!.Value };
-            return result.AsExchangeResult<SharedPosition[]>(Exchange, resultTypes, data.Select(x =>
+            return HttpResult.Ok(result, data.Select(x =>
             new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.Quantity), x.UpdateTime)
             {
                 UnrealizedPnl = x.Pnl,
@@ -1423,7 +1388,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        EndpointOptions<ClosePositionRequest> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest>(true)
+        EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient>(_exchange, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1431,11 +1396,11 @@ namespace WhiteBit.Net.Clients.V4Api
                 new ParameterDescription(nameof(ClosePositionRequest.Quantity), typeof(decimal), "Quantity of the position is required", 0.1m),
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).ClosePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.ClosePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await CollateralTrading.PlaceOrderAsync(
@@ -1444,48 +1409,48 @@ namespace WhiteBit.Net.Clients.V4Api
                 NewOrderType.Market,
                 request.Quantity,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(false);
+        EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchange, false);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
             // Get data
             var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFee>(result);
 
             var symbol = result.Data.SingleOrDefault(x => x.Name == request.Symbol!.GetSymbol(FormatSymbol));
             if (symbol == null)
-                return result.AsExchangeError<SharedFee>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedFee>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
             // Return
-            return result.AsExchangeResult(Exchange, request.TradingMode, new SharedFee(symbol.MakerFee, symbol.TakerFee));
+            return HttpResult.Ok(result, new SharedFee(symbol.MakerFee, symbol.TakerFee));
         }
         #endregion
 
         #region Spot Trigger Order Client
 
-        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(true)
+        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(_exchange, true)
         {
         };
 
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).PlaceSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes, ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceSpotOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1497,33 +1462,33 @@ namespace WhiteBit.Net.Clients.V4Api
                 price: request.OrderPrice,
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true)
+        EndpointOptions<GetOrderRequest, ISpotTriggerOrderRestClient> ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotTriggerOrderRestClient>(_exchange, true)
         {
         };
-        async Task<ExchangeWebResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).GetSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTriggerOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedSpotTriggerOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedSpotTriggerOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var openOrders = await Trading.GetOpenOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!openOrders)
-                return openOrders.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+            if (!openOrders.Success)
+                return HttpResult.Fail<SharedSpotTriggerOrder>(openOrders);
 
             var openOrder = openOrders.Data.SingleOrDefault();
             if (openOrder != null)
             {
-                return openOrders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTriggerOrder(
+                return HttpResult.Ok(openOrders, new SharedSpotTriggerOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicSpotId, openOrder.Symbol),
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
@@ -1547,14 +1512,14 @@ namespace WhiteBit.Net.Clients.V4Api
             else
             {
                 var closeOrders = await Trading.GetClosedOrdersAsync(request.Symbol.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-                if (!closeOrders)
-                    return closeOrders.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+                if (!closeOrders.Success)
+                    return HttpResult.Fail<SharedSpotTriggerOrder>(closeOrders);
 
                 if (!closeOrders.Data.Any())
-                    return closeOrders.AsExchangeError<SharedSpotTriggerOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                    return HttpResult.Fail<SharedSpotTriggerOrder>(closeOrders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
                 var closedOrder = closeOrders.Data.Single().Value.Single();
-                return closeOrders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTriggerOrder(
+                return HttpResult.Ok(closeOrders, new SharedSpotTriggerOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicSpotId, closedOrder.Symbol),
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
@@ -1577,39 +1542,39 @@ namespace WhiteBit.Net.Clients.V4Api
             }
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, ISpotTriggerOrderRestClient> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotTriggerOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).CancelSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 orderId,
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         #endregion
 
         #region Futures Trigger Order Client
-        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(false)
+        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(_exchange, false)
         {
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
         {
             var side = GetOrderSide(request);
-            var validationError = ((IFuturesTriggerOrderRestClient)this).PlaceFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes, side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell, ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await CollateralTrading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1621,11 +1586,11 @@ namespace WhiteBit.Net.Clients.V4Api
                 clientOrderId: request.ClientOrderId,
                 positionSide: request.PositionSide.ToPositionSide(),
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
         private OrderSide GetOrderSide(PlaceFuturesTriggerOrderRequest request)
@@ -1636,26 +1601,26 @@ namespace WhiteBit.Net.Clients.V4Api
             return request.OrderDirection == SharedTriggerOrderDirection.Enter ? OrderSide.Sell : OrderSide.Buy;
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true)
+        EndpointOptions<GetOrderRequest, IFuturesTriggerOrderRestClient> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesTriggerOrderRestClient>(_exchange, true)
         {
         };
-        async Task<ExchangeWebResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).GetFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedFuturesTriggerOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var openOrders = await Trading.GetOpenOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!openOrders)
-                return openOrders.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+            if (!openOrders.Success)
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(openOrders);
 
             var openOrder = openOrders.Data.SingleOrDefault();
             if (openOrder != null)
             {
-                return openOrders.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesTriggerOrder(
+                return HttpResult.Ok(openOrders, new SharedFuturesTriggerOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicFuturesId, openOrder.Symbol),
                     openOrder.Symbol,
                     openOrder.OrderId.ToString(),
@@ -1680,15 +1645,15 @@ namespace WhiteBit.Net.Clients.V4Api
             else
             {
                 var closeOrders = await Trading.GetClosedOrdersAsync(request.Symbol.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-                if (!closeOrders)
-                    return closeOrders.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+                if (!closeOrders.Success)
+                    return HttpResult.Fail<SharedFuturesTriggerOrder>(closeOrders);
 
                 if (!closeOrders.Data.Any())
-                    return closeOrders.AsExchangeError<SharedFuturesTriggerOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                    return HttpResult.Fail<SharedFuturesTriggerOrder>(closeOrders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
                 var closedOrder = closeOrders.Data.Single().Value.Single();
                 
-                return closeOrders.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesTriggerOrder(
+                return HttpResult.Ok(closeOrders, new SharedFuturesTriggerOrder(
                     ExchangeSymbolCache.ParseSymbol(_topicFuturesId, closedOrder.Symbol),
                     closedOrder.Symbol,
                     closedOrder.OrderId.ToString(),
@@ -1725,30 +1690,30 @@ namespace WhiteBit.Net.Clients.V4Api
             return SharedTriggerOrderStatus.Unknown;
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, IFuturesTriggerOrderRestClient> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesTriggerOrderRestClient>(_exchange, true);
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).CancelFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 orderId,
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest>(true)
+        EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient>(_exchange, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1756,11 +1721,11 @@ namespace WhiteBit.Net.Clients.V4Api
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).SetFuturesTpSlOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SetFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await CollateralTrading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1770,14 +1735,14 @@ namespace WhiteBit.Net.Clients.V4Api
                 triggerPrice: request.TriggerPrice,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<CancelTpSlRequest> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest>(true)
+        EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient>(_exchange, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1785,36 +1750,36 @@ namespace WhiteBit.Net.Clients.V4Api
             }
         };
 
-        async Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).CancelFuturesTpSlOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<bool>(Exchange, validationError);
+                return HttpResult.Fail<bool>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<bool>(Exchange, ArgumentError.Invalid(nameof(CancelTpSlRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<bool>(Exchange, ArgumentError.Invalid(nameof(CancelTpSlRequest.OrderId), "Invalid order id"));
 
             var result = await Trading.CancelOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 orderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<bool>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<bool>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, true);
+            return HttpResult.Ok(result, true);
         }
 
         #endregion
 
         #region Funding Rate client
-        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(false, true, true, 100, false);
+        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchange, false, true, true, 100, false);
 
-        async Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFundingRateRestClient)this).GetFundingRateHistoryOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFundingRateHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFundingRate[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFundingRate[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 100;
@@ -1828,8 +1793,8 @@ namespace WhiteBit.Net.Clients.V4Api
                 limit: limit,
                 offset: pageParams.Offset,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFundingRate[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFundingRate[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                  () => Pagination.NextPageFromOffset(pageParams, limit),
@@ -1839,10 +1804,7 @@ namespace WhiteBit.Net.Clients.V4Api
                  request.EndTime ?? DateTime.UtcNow,
                  pageParams);
 
-            return result.AsExchangeResult(
-                       Exchange,
-                       request.Symbol.TradingMode,
-                       ExchangeHelpers.ApplyFilter(result.Data, x => x.FundingTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.FundingTime, request.StartTime, request.EndTime, direction)
                        .Select(x => 
                            new SharedFundingRate(x.FundingRate, x.FundingTime))
                        .ToArray(), nextPageRequest);
@@ -1851,23 +1813,23 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Transfer client
 
-        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions([
+        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions(_exchange, [
             SharedAccountType.Spot,
             SharedAccountType.PerpetualLinearFutures,
             SharedAccountType.PerpetualInverseFutures,
             SharedAccountType.DeliveryLinearFutures,
             SharedAccountType.DeliveryInverseFutures
             ]);
-        async Task<ExchangeWebResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
         {
-            var validationError = ((ITransferRestClient)this).TransferOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.TransferOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var fromType = GetTransferType(request.FromAccountType);
             var toType = GetTransferType(request.ToAccountType);
             if (fromType == null || toType == null)
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
 
             // Get data
             var transfer = await Account.TransferAsync(
@@ -1876,10 +1838,10 @@ namespace WhiteBit.Net.Clients.V4Api
                 request.Asset,
                 request.Quantity,
                 ct: ct).ConfigureAwait(false);
-            if (!transfer)
-                return transfer.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!transfer.Success)
+                return HttpResult.Fail<SharedId>(transfer);
 
-            return transfer.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(""));
+            return HttpResult.Ok(transfer, new SharedId(""));
         }
 
         private AccountType? GetTransferType(SharedAccountType type)

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiShared.cs
@@ -20,16 +20,15 @@ namespace WhiteBit.Net.Clients.V4Api
         private const string _topicSpotId = "WhiteBitSpot";
         private const string _topicFuturesId = "WhiteBitFutures";
 
-        public string Exchange => _exchange;
-
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear };
         public TradingMode[] SupportedFuturesModes => new[] { TradingMode.PerpetualLinear };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Spot Symbol client
-        EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient>(_exchange, false);
+        GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchange, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -51,7 +50,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 PriceDecimals = s.QuoteAssetPrecision
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
             return response;
         }
 
@@ -140,7 +139,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchange, false);
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchange, false);
         async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
@@ -250,7 +249,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region Asset client
-        EndpointOptions<GetAssetsRequest, IAssetsRestClient> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest, IAssetsRestClient>(_exchange, true);
+        GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchange, true);
 
         async Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
@@ -277,7 +276,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        EndpointOptions<GetAssetRequest, IAssetsRestClient> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest, IAssetsRestClient>(_exchange, false);
+        GetAssetOptions IAssetsRestClient.GetAssetOptions { get; } = new GetAssetOptions(_exchange, false);
         async Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetAssetOptions.ValidateRequest(request, this);
@@ -308,7 +307,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Deposit client
 
-        EndpointOptions<GetDepositAddressesRequest, IDepositRestClient> IDepositRestClient.GetDepositAddressesOptions { get; } = new EndpointOptions<GetDepositAddressesRequest, IDepositRestClient>(_exchange, true);
+        GetDepositAddressesOptions IDepositRestClient.GetDepositAddressesOptions { get; } = new GetDepositAddressesOptions(_exchange, true);
         async Task<HttpResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetDepositAddressesOptions.ValidateRequest(request, this);
@@ -385,7 +384,9 @@ namespace WhiteBit.Net.Clients.V4Api
                 || transactionStatus == TransactionStatus.ConfirmationInProgress
                 || transactionStatus == TransactionStatus.Pending
                 || transactionStatus == TransactionStatus.Uncredited)
+            {
                 return SharedTransferStatus.InProgress;
+            }
 
             return SharedTransferStatus.Unknown;
         }
@@ -506,7 +507,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderRestClient>(_exchange, true);
+        GetSpotOrderOptions ISpotOrderRestClient.GetSpotOrderOptions { get; } = new GetSpotOrderOptions(_exchange, true);
         async Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
@@ -579,7 +580,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }
         }
 
-        EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient>(_exchange, true);
+        GetOpenSpotOrdersOptions ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new GetOpenSpotOrdersOptions(_exchange, true);
         async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetOpenSpotOrdersOptions.ValidateRequest(request, this);
@@ -674,7 +675,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.CreateTime!.Value, request.StartTime, request.EndTime, direction).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient>(_exchange, true);
+        GetSpotOrderTradesOptions ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new GetSpotOrderTradesOptions(_exchange, true);
         async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetSpotOrderTradesOptions.ValidateRequest(request, this);
@@ -757,7 +758,7 @@ namespace WhiteBit.Net.Clients.V4Api
                         }).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderRestClient>(_exchange, true);
+        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchange, true);
         async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
@@ -796,7 +797,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Futures Symbol client
 
-        EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient>(_exchange, false);
+        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchange, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetFuturesSymbolsOptions.ValidateRequest(request, this);
@@ -827,7 +828,7 @@ namespace WhiteBit.Net.Clients.V4Api
                     };
                 }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, response.Data!);
             return response;
         }
 
@@ -925,7 +926,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerAccount;
 
-        EndpointOptions<GetLeverageRequest, ILeverageRestClient> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest, ILeverageRestClient>(_exchange, true);
+        GetLeverageOptions ILeverageRestClient.GetLeverageOptions { get; } = new GetLeverageOptions(_exchange, true);
         async Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetLeverageOptions.ValidateRequest(request, this);
@@ -956,7 +957,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient>(_exchange, true);
+        GetOpenInterestOptions IOpenInterestRestClient.GetOpenInterestOptions { get; } = new GetOpenInterestOptions(_exchange, true);
         async Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetOpenInterestOptions.ValidateRequest(request, this);
@@ -1076,7 +1077,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderRestClient>(_exchange, true);
+        GetFuturesOrderOptions IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new GetFuturesOrderOptions(_exchange, true);
         async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
@@ -1157,7 +1158,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }            
         }
 
-        EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient>(_exchange, true);
+        GetOpenFuturesOrdersOptions IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new GetOpenFuturesOrdersOptions(_exchange, true);
         async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetOpenFuturesOrdersOptions.ValidateRequest(request, this);
@@ -1260,7 +1261,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.CreateTime!.Value, request.StartTime, request.EndTime, direction).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient>(_exchange, true);
+        GetFuturesOrderTradesOptions IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new GetFuturesOrderTradesOptions(_exchange, true);
         async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetFuturesOrderTradesOptions.ValidateRequest(request, this);
@@ -1345,7 +1346,7 @@ namespace WhiteBit.Net.Clients.V4Api
                        .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient>(_exchange, true);
+        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchange, true);
         async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
@@ -1362,7 +1363,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(order, new SharedId(order.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient>(_exchange, true);
+        GetPositionsOptions IFuturesOrderRestClient.GetPositionsOptions { get; } = new GetPositionsOptions(_exchange, true);
         async Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.GetPositionsOptions.ValidateRequest(request, this);
@@ -1388,7 +1389,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }).ToArray());
         }
 
-        EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient>(_exchange, true)
+        ClosePositionOptions IFuturesOrderRestClient.ClosePositionOptions { get; } = new ClosePositionOptions(_exchange, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1418,7 +1419,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchange, false);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchange, false);
 
         async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
@@ -1469,7 +1470,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest, ISpotTriggerOrderRestClient> ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotTriggerOrderRestClient>(_exchange, true)
+        GetSpotTriggerOrderOptions ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new GetSpotTriggerOrderOptions(_exchange, true)
         {
         };
         async Task<HttpResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
@@ -1542,7 +1543,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }
         }
 
-        EndpointOptions<CancelOrderRequest, ISpotTriggerOrderRestClient> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotTriggerOrderRestClient>(_exchange, true);
+        CancelSpotTriggerOrderOptions ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new CancelSpotTriggerOrderOptions(_exchange, true);
         async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelSpotTriggerOrderOptions.ValidateRequest(request, this);
@@ -1601,7 +1602,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return request.OrderDirection == SharedTriggerOrderDirection.Enter ? OrderSide.Sell : OrderSide.Buy;
         }
 
-        EndpointOptions<GetOrderRequest, IFuturesTriggerOrderRestClient> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesTriggerOrderRestClient>(_exchange, true)
+        GetFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new GetFuturesTriggerOrderOptions(_exchange, true)
         {
         };
         async Task<HttpResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
@@ -1690,7 +1691,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return SharedTriggerOrderStatus.Unknown;
         }
 
-        EndpointOptions<CancelOrderRequest, IFuturesTriggerOrderRestClient> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesTriggerOrderRestClient>(_exchange, true);
+        CancelFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new CancelFuturesTriggerOrderOptions(_exchange, true);
         async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelFuturesTriggerOrderOptions.ValidateRequest(request, this);
@@ -1713,7 +1714,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient>(_exchange, true)
+        SetFuturesTpSlOptions IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new SetFuturesTpSlOptions(_exchange, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1742,7 +1743,7 @@ namespace WhiteBit.Net.Clients.V4Api
             return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
         }
 
-        EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient>(_exchange, true)
+        CancelFuturesTpSlOptions IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new CancelFuturesTpSlOptions(_exchange, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiSubAccount.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiSubAccount.cs
@@ -36,7 +36,7 @@ namespace WhiteBit.Net.Clients.V4Api
             permissions.Add("spotEnabled", spotEnabled);
             permissions.Add("collateralEnabled", collateralEnabled);
             parameters.Add("permissions", permissions);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/create", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/create", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSubAccount>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -51,7 +51,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/delete", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/delete", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -71,7 +71,7 @@ namespace WhiteBit.Net.Clients.V4Api
             permissions.Add("spotEnabled", spotEnabled);
             permissions.Add("collateralEnabled", collateralEnabled);
             parameters.Add("permissions", permissions);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/edit", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/edit", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -88,7 +88,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("search", search);
             parameters.Add("", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/list", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/list", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSubAccounts>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -106,7 +106,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("direction", direction);
             parameters.Add("ticker", asset);
             parameters.Add("amount", quantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/transfer", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/transfer", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); ;
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -121,7 +121,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/block", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/block", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -136,7 +136,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/unblock", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/unblock", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -152,7 +152,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
             parameters.Add("ticker", asset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/balances", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/balances", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitSubBalances>>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
@@ -172,7 +172,7 @@ namespace WhiteBit.Net.Clients.V4Api
         public async Task<HttpResult<WhiteBitSubaccountTransferHistory>> GetSubaccountTransferHistoryAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/transfer/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/sub-account/transfer/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSubaccountTransferHistory>(request, parameters, ct).ConfigureAwait(false);
             return result;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiSubAccount.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiSubAccount.cs
@@ -26,15 +26,15 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Create Sub Account
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitSubAccount>> CreateSubAccountAsync(string alias, string? email = null, bool? shareKyc = null, string? spotEnabled = null, string? collateralEnabled = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitSubAccount>> CreateSubAccountAsync(string alias, string? email = null, bool? shareKyc = null, string? spotEnabled = null, string? collateralEnabled = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("alias", alias);
-            parameters.AddOptional("email", email);
-            parameters.AddOptional("shareKyc", shareKyc);
-            var permissions = new ParameterCollection();
-            permissions.AddOptional("spotEnabled", spotEnabled);
-            permissions.AddOptional("collateralEnabled", collateralEnabled);
+            parameters.Add("email", email);
+            parameters.Add("shareKyc", shareKyc);
+            var permissions = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            permissions.Add("spotEnabled", spotEnabled);
+            permissions.Add("collateralEnabled", collateralEnabled);
             parameters.Add("permissions", permissions);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/create", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -47,9 +47,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Delete Sub Account
 
         /// <inheritdoc />
-        public async Task<WebCallResult> DeleteSubAccountAsync(string id, CancellationToken ct = default)
+        public async Task<HttpResult> DeleteSubAccountAsync(string id, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/delete", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -62,12 +62,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Edit Sub Account
 
         /// <inheritdoc />
-        public async Task<WebCallResult> EditSubAccountAsync(string id, string alias, string spotEnabled, string collateralEnabled, CancellationToken ct = default)
+        public async Task<HttpResult> EditSubAccountAsync(string id, string alias, string spotEnabled, string collateralEnabled, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
             parameters.Add("alias", alias);
-            var permissions = new ParameterCollection();
+            var permissions = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             permissions.Add("spotEnabled", spotEnabled);
             permissions.Add("collateralEnabled", collateralEnabled);
             parameters.Add("permissions", permissions);
@@ -82,12 +82,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Sub Accounts
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitSubAccounts>> GetSubAccountsAsync(string? search = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitSubAccounts>> GetSubAccountsAsync(string? search = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("search", search);
-            parameters.AddOptional("", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("search", search);
+            parameters.Add("", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/list", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSubAccounts>(request, parameters, ct).ConfigureAwait(false);
@@ -99,13 +99,13 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Subaccount Transfer
 
         /// <inheritdoc />
-        public async Task<WebCallResult> SubaccountTransferAsync(string subaccountId, SubTransferDirection direction, string asset, decimal quantity, CancellationToken ct = default)
+        public async Task<HttpResult> SubaccountTransferAsync(string subaccountId, SubTransferDirection direction, string asset, decimal quantity, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", subaccountId);
-            parameters.AddEnum("direction", direction);
+            parameters.Add("direction", direction);
             parameters.Add("ticker", asset);
-            parameters.AddString("amount", quantity);
+            parameters.Add("amount", quantity);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/transfer", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); ;
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
@@ -117,9 +117,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Block Subaccount
 
         /// <inheritdoc />
-        public async Task<WebCallResult> BlockSubaccountAsync(string id, CancellationToken ct = default)
+        public async Task<HttpResult> BlockSubaccountAsync(string id, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/block", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -132,9 +132,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Block Subaccount
 
         /// <inheritdoc />
-        public async Task<WebCallResult> UnblockSubaccountAsync(string id, CancellationToken ct = default)
+        public async Task<HttpResult> UnblockSubaccountAsync(string id, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/unblock", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -147,21 +147,21 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Subaccount Balances
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitSubBalances[]>> GetSubaccountBalancesAsync(string id, string? asset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitSubBalances[]>> GetSubaccountBalancesAsync(string id, string? asset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("id", id);
-            parameters.AddOptional("ticker", asset);
+            parameters.Add("ticker", asset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/balances", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitSubBalances>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<WhiteBitSubBalances[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitSubBalances[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return result.As<WhiteBitSubBalances[]>(result.Data.Select(x => x.Value).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => x.Value).ToArray());
         }
 
         #endregion
@@ -169,9 +169,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Subaccount Transfer History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitSubaccountTransferHistory>> GetSubaccountTransferHistoryAsync(CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitSubaccountTransferHistory>> GetSubaccountTransferHistoryAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/sub-account/transfer/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitSubaccountTransferHistory>(request, parameters, ct).ConfigureAwait(false);

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiTrading.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiTrading.cs
@@ -91,7 +91,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 throw new ArgumentException("Unknown path for order type");
             }
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, path, WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, path, WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -108,7 +108,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("orders", requests.ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/bulk", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/bulk", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var resultData = await _baseClient.SendAsync<WhiteBitOrderResponse[]>(request, parameters, ct).ConfigureAwait(false);
             if (!resultData.Success)
                 return HttpResult.Fail<CallResult<WhiteBitOrderResponse>[]>(resultData);
@@ -149,7 +149,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("market", symbol);
             parameters.Add("orderId", orderId);
             parameters.Add("clientOrderId", clientOrderId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -164,7 +164,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("orders", requests.ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/cancel/bulk", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/cancel/bulk", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitCancelOrdersResult[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -179,8 +179,8 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            parameters.Add("type", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/cancel/all", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            parameters.AddRaw("type", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/cancel/all", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -199,7 +199,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("clientOrderId", clientOrderId);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/orders", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/orders", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -230,7 +230,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("offset", offset);
             parameters.Add("startDate", startTime);
             parameters.Add("endDate", endTime);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/order/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/trade-account/order/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitClosedOrder[]>>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
@@ -262,7 +262,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("endTime", endDate);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/executed-history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/trade-account/executed-history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             if (symbol != null)
             {
@@ -296,10 +296,13 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("orderId", orderId);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/order", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/trade-account/order", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOffsetResult<WhiteBitUserTrade>>(request, parameters, ct).ConfigureAwait(false);
-            return HttpResult.Ok(result, result.Data?.Records);
+            if (!result.Success)
+                return HttpResult.Fail<WhiteBitUserTrade[]>(result);
+
+            return HttpResult.Ok(result, result.Data.Records);
         }
 
         #endregion
@@ -317,7 +320,7 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("total", quoteQuantity);
             parameters.Add("price", price);
             parameters.Add("activationPrice", triggerPrice);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/modify", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/modify", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -335,8 +338,8 @@ namespace WhiteBit.Net.Clients.V4Api
 #pragma warning disable CS8604 // Possible null reference argument. Works as intended
             parameters.Add("timeout", timeout == 0 ? null : timeout.ToString());
 #pragma warning restore CS8604 // Possible null reference argument.
-            parameters.Add("types", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/kill-switch", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            parameters.AddRaw("types", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/kill-switch", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -351,7 +354,7 @@ namespace WhiteBit.Net.Clients.V4Api
         {
             var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/kill-switch/status", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/order/kill-switch/status", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitKillSwitch[]>(request, parameters, ct).ConfigureAwait(false);
             return result;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiTrading.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiTrading.cs
@@ -32,7 +32,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Place Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOrder>> PlaceSpotOrderAsync(
+        public async Task<HttpResult<WhiteBitOrder>> PlaceSpotOrderAsync(
             string symbol,
             OrderSide side,
             NewOrderType type,
@@ -48,19 +48,19 @@ namespace WhiteBit.Net.Clients.V4Api
             CancellationToken ct = default)
         {
             if (quoteQuantity != null && type != NewOrderType.Market && side != OrderSide.Buy)
-                return new WebCallResult<WhiteBitOrder>(ArgumentError.Invalid(nameof(quoteQuantity), "quoteQuantity parameter only supported for buy market orders"));
+                return HttpResult.Fail<WhiteBitOrder>(WhiteBitExchange.ExchangeName, ArgumentError.Invalid(nameof(quoteQuantity), "quoteQuantity parameter only supported for buy market orders"));
 
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            parameters.AddEnum("side", side);
-            parameters.AddString("amount", quantity ?? quoteQuantity ?? 0);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptional("clientOrderId", clientOrderId);
-            parameters.AddOptional("postOnly", postOnly);
-            parameters.AddOptional("ioc", immediateOrCancel);
-            parameters.AddOptional("bboRole", bboRole);
-            parameters.AddOptionalString("activation_price", triggerPrice);
-            parameters.AddOptionalEnum("stp", stpMode);
+            parameters.Add("side", side);
+            parameters.Add("amount", quantity ?? quoteQuantity ?? 0);
+            parameters.Add("price", price);
+            parameters.Add("clientOrderId", clientOrderId);
+            parameters.Add("postOnly", postOnly);
+            parameters.Add("ioc", immediateOrCancel);
+            parameters.Add("bboRole", bboRole);
+            parameters.Add("activation_price", triggerPrice);
+            parameters.Add("stp", stpMode);
 
             string path;
             if (type == NewOrderType.Limit)
@@ -102,23 +102,23 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Place Multiple Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<WhiteBitOrderResponse>[]>> PlaceSpotMultipleOrdersAsync(
+        public async Task<HttpResult<CallResult<WhiteBitOrderResponse>[]>> PlaceSpotMultipleOrdersAsync(
             IEnumerable<WhiteBitOrderRequest> requests,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("orders", requests.ToArray());
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/bulk", WhiteBitExchange.RateLimiter.WhiteBit, 1, true);
             var resultData = await _baseClient.SendAsync<WhiteBitOrderResponse[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!resultData)
-                return resultData.As<CallResult<WhiteBitOrderResponse>[]>(default);
+            if (!resultData.Success)
+                return HttpResult.Fail<CallResult<WhiteBitOrderResponse>[]>(resultData);
 
             var result = new List<CallResult<WhiteBitOrderResponse>>();
             foreach (var item in resultData.Data)
             {
                 if (item.Error?.Code == null)
                 {
-                    result.Add(new CallResult<WhiteBitOrderResponse>(item));
+                    result.Add(CallResult.Ok(item));
                 }
                 else
                 {
@@ -128,14 +128,14 @@ namespace WhiteBit.Net.Clients.V4Api
                     else
                         error = new ServerError(item.Error.Code, _baseClient.GetErrorInfo(item.Error.Code, item.Error.Message!));
 
-                    result.Add(new CallResult<WhiteBitOrderResponse>(error));
+                    result.Add(CallResult.Fail<WhiteBitOrderResponse>(error));
                 }
             }
 
             if (result.All(x => !x.Success))
-                return resultData.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return HttpResult.Fail(resultData, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return resultData.As(result.ToArray());
+            return HttpResult.Ok(resultData, result.ToArray());
         }
 
         #endregion
@@ -143,12 +143,12 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Cancel Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOrder>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitOrder>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
-            parameters.AddOptional("orderId", orderId);
-            parameters.AddOptional("clientOrderId", clientOrderId);
+            parameters.Add("orderId", orderId);
+            parameters.Add("clientOrderId", clientOrderId);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/cancel", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder>(request, parameters, ct).ConfigureAwait(false);
@@ -160,9 +160,9 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Cancel Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitCancelOrdersResult[]>> CancelOrdersAsync(IEnumerable<WhiteBitCancelRequest> requests, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitCancelOrdersResult[]>> CancelOrdersAsync(IEnumerable<WhiteBitCancelRequest> requests, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("orders", requests.ToArray());
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/cancel/bulk", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
@@ -175,11 +175,11 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Cancel All Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelAllOrdersAsync(string? symbol = null, IEnumerable<OrderProductType>? orderProductTypes = null, CancellationToken ct = default)
+        public async Task<HttpResult> CancelAllOrdersAsync(string? symbol = null, IEnumerable<OrderProductType>? orderProductTypes = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("type", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("type", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/cancel/all", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
@@ -191,14 +191,14 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Open Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOrder[]>> GetOpenOrdersAsync(string? symbol = null, long? orderId = null, string? clientOrderId = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitOrder[]>> GetOpenOrdersAsync(string? symbol = null, long? orderId = null, string? clientOrderId = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("orderId", orderId);
-            parameters.AddOptional("clientOrderId", clientOrderId);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("orderId", orderId);
+            parameters.Add("clientOrderId", clientOrderId);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/orders", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder[]>(request, parameters, ct).ConfigureAwait(false);
@@ -210,7 +210,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Closed Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, WhiteBitClosedOrder[]>>> GetClosedOrdersAsync(
+        public async Task<HttpResult<Dictionary<string, WhiteBitClosedOrder[]>>> GetClosedOrdersAsync(
             string? symbol = null, 
             long? orderId = null, 
             string? clientOrderId = null,
@@ -221,23 +221,23 @@ namespace WhiteBit.Net.Clients.V4Api
             DateTime? endTime = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("orderId", orderId);
-            parameters.AddOptional("clientOrderId", clientOrderId);
-            parameters.AddOptionalEnum("status", status);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
-            parameters.AddOptionalSeconds("startDate", startTime);
-            parameters.AddOptionalSeconds("endDate", endTime);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("orderId", orderId);
+            parameters.Add("clientOrderId", clientOrderId);
+            parameters.Add("status", status);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
+            parameters.Add("startDate", startTime);
+            parameters.Add("endDate", endTime);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/order/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitClosedOrder[]>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             if (result.Data == null)
-                return result.As(new Dictionary<string, WhiteBitClosedOrder[]>());
+                return HttpResult.Ok(result, new Dictionary<string, WhiteBitClosedOrder[]>());
 
             foreach (var symbolOrders in result.Data)
             {
@@ -253,15 +253,15 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get User Trades
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitUserTrade[]>> GetUserTradesAsync(string? symbol = null, string? clientOrderId = null, DateTime? startDate = null, DateTime? endDate = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitUserTrade[]>> GetUserTradesAsync(string? symbol = null, string? clientOrderId = null, DateTime? startDate = null, DateTime? endDate = null, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("clientOrderId", clientOrderId);
-            parameters.AddOptionalSeconds("startTime", startDate);
-            parameters.AddOptionalSeconds("endTime", endDate);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("clientOrderId", clientOrderId);
+            parameters.Add("startTime", startDate);
+            parameters.Add("endTime", endDate);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/executed-history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             if (symbol != null)
@@ -272,8 +272,8 @@ namespace WhiteBit.Net.Clients.V4Api
             else
             {
                 var result = await _baseClient.SendAsync<Dictionary<string, WhiteBitUserTrade[]>>(request, parameters, ct).ConfigureAwait(false);
-                if (!result)
-                    return result.As<WhiteBitUserTrade[]>(default);
+                if (!result.Success)
+                    return HttpResult.Fail<WhiteBitUserTrade[]>(result);
 
                 foreach (var item in result.Data)
                 {
@@ -281,7 +281,7 @@ namespace WhiteBit.Net.Clients.V4Api
                         x.Symbol = item.Key;
                 }
 
-                return result.As<WhiteBitUserTrade[]>(result.Data.Values.SelectMany(x => x).OrderByDescending(x => x.Time).ToArray());
+                return HttpResult.Ok(result, result.Data.Values.SelectMany(x => x).OrderByDescending(x => x.Time).ToArray());
             }
         }
 
@@ -290,16 +290,16 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Order Trades
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitUserTrade[]>> GetOrderTradesAsync(long orderId, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitUserTrade[]>> GetOrderTradesAsync(long orderId, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("orderId", orderId);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("offset", offset);
+            parameters.Add("limit", limit);
+            parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/trade-account/order", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(12000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOffsetResult<WhiteBitUserTrade>>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<WhiteBitUserTrade[]>(result.Data?.Records);
+            return HttpResult.Ok(result, result.Data?.Records);
         }
 
         #endregion
@@ -307,16 +307,16 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Edit Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitOrder>> EditOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, decimal? quantity = null, decimal? quoteQuantity = null, decimal? price = null, decimal? triggerPrice = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitOrder>> EditOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, decimal? quantity = null, decimal? quoteQuantity = null, decimal? price = null, decimal? triggerPrice = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("orderId", orderId);
-            parameters.AddOptional("clientOrderId", clientOrderId);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("orderId", orderId);
+            parameters.Add("clientOrderId", clientOrderId);
             parameters.Add("market", symbol);
-            parameters.AddOptionalString("amount", quantity);
-            parameters.AddOptionalString("total", quoteQuantity);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptionalString("activationPrice", triggerPrice);
+            parameters.Add("amount", quantity);
+            parameters.Add("total", quoteQuantity);
+            parameters.Add("price", price);
+            parameters.Add("activationPrice", triggerPrice);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/modify", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitOrder>(request, parameters, ct).ConfigureAwait(false);
@@ -328,14 +328,14 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Set Kill Switch
 
         /// <inheritdoc />
-        public async Task<WebCallResult> SetKillSwitchAsync(string symbol, int timeout, IEnumerable<OrderProductType>? orderProductTypes = null, CancellationToken ct = default)
+        public async Task<HttpResult> SetKillSwitchAsync(string symbol, int timeout, IEnumerable<OrderProductType>? orderProductTypes = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
             parameters.Add("market", symbol);
 #pragma warning disable CS8604 // Possible null reference argument. Works as intended
             parameters.Add("timeout", timeout == 0 ? null : timeout.ToString());
 #pragma warning restore CS8604 // Possible null reference argument.
-            parameters.AddOptional("types", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
+            parameters.Add("types", orderProductTypes?.Select(EnumConverter.GetString).ToArray());
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/kill-switch", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
@@ -347,10 +347,10 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Get Kill Switch
 
         /// <inheritdoc />
-        public async Task<WebCallResult<WhiteBitKillSwitch[]>> GetKillSwitchStatusAsync(string? symbol = null, CancellationToken ct = default)
+        public async Task<HttpResult<WhiteBitKillSwitch[]>> GetKillSwitchStatusAsync(string? symbol = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
+            var parameters = new Parameters(WhiteBitExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v4/order/kill-switch/status", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,
                 limitGuard: new SingleLimitGuard(10000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<WhiteBitKillSwitch[]>(request, parameters, ct).ConfigureAwait(false);

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
@@ -526,7 +526,10 @@ namespace WhiteBit.Net.Clients.V4Api
             }, auth);
 
             var result = await QueryAsync(BaseAddress.AppendPath("ws"), query, ct).ConfigureAwait(false);
-            return WebSocketResult.Ok(result, result.Data == null ? default : result.Data.Result);
+            if (!result.Success)
+                return WebSocketResult.Fail<T>(result);
+
+            return WebSocketResult.Ok(result, result.Data.Result);
         }
 
         /// <inheritdoc />
@@ -550,13 +553,13 @@ namespace WhiteBit.Net.Clients.V4Api
         private async Task<WebSocketResult<string>> GetTokenAsync()
         {
             if (ApiCredentials == null)
-                return WebSocketResult.Fail<string>(ExchangeName, new NoApiCredentialsError());
+                return WebSocketResult.Fail<string>(Exchange, new NoApiCredentialsError());
 
             if (_tokenCache.TryGetValue(ApiCredentials.Key, out var token) && token.Expire > DateTime.UtcNow)
-                return new WebSocketResult<string>(ExchangeName, token.Token, null);
+                return new WebSocketResult<string>(Exchange, token.Token, null);
 
             if (ClientOptions.Environment.Name == "UnitTest")
-                return new WebSocketResult<string>(ExchangeName, "123", null);
+                return new WebSocketResult<string>(Exchange, "123", null);
 
             _logger.LogDebug("Requesting websocket token");
             var restClient = new WhiteBitRestClient(x =>
@@ -569,11 +572,11 @@ namespace WhiteBit.Net.Clients.V4Api
             if (!result.Success)
             {
                 _logger.LogWarning("Failed to retrieve websocket token: {Error}", result.Error);
-                return WebSocketResult.Fail<string>(ExchangeName, result.Error!);
+                return WebSocketResult.Fail<string>(Exchange, result.Error!);
             }
 
             _tokenCache[ApiCredentials.Key] = new CachedToken { Token = result.Data, Expire = DateTime.UtcNow.AddSeconds(60) };
-            return new WebSocketResult<string>(ExchangeName, result.Data, null);
+            return new WebSocketResult<string>(Exchange, result.Data, null);
         }
 
         private class CachedToken

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
@@ -87,7 +87,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Trades
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitSocketTrade[]>(
                 "trades_request",
@@ -129,7 +129,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Last Price
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default)
+        public async Task<QueryResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default)
         {
             var result = await QueryAsync<decimal?>(
                 "lastprice_request",
@@ -137,9 +137,9 @@ namespace WhiteBit.Net.Clients.V4Api
                 ct,
                 symbol).ConfigureAwait(false);
             if (!result.Success)
-                return WebSocketResult.Fail<decimal>(result);
+                return QueryResult.Fail<decimal>(result);
 
-            return WebSocketResult.Ok(result, result.Data ?? default);
+            return QueryResult.Ok(result, result.Data ?? default);
         }
 
         /// <inheritdoc />
@@ -168,7 +168,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Ticker
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitSocketTicker>(
                 "market_request",
@@ -252,7 +252,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Kline
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitKlineUpdate[]>(
                 "candles_request",
@@ -276,7 +276,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Order book
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default)
         {
             depth.ValidateIntBetween(nameof(depth), 0, 100);
 
@@ -303,7 +303,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Spot Balances
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default)
         {
             var result = await QueryAsync<Dictionary<string, WhiteBitTradeBalance>>(
                 "balanceSpot_request",
@@ -311,12 +311,12 @@ namespace WhiteBit.Net.Clients.V4Api
                 ct).ConfigureAwait(false);
 
             if (!result.Success)
-                return WebSocketResult.Fail<WhiteBitTradeBalance[]>(result);
+                return QueryResult.Fail<WhiteBitTradeBalance[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return WebSocketResult.Ok(result, result.Data.Values.ToArray());
+            return QueryResult.Ok(result, result.Data.Values.ToArray());
         }
 
         /// <inheritdoc />
@@ -330,7 +330,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Margin Balances
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default)
         {
             var result = await QueryAsync<Dictionary<string, WhiteBitMarginBalance>>(
                 "balanceMargin_request",
@@ -338,12 +338,12 @@ namespace WhiteBit.Net.Clients.V4Api
                 ct).ConfigureAwait(false);
 
             if (!result.Success)
-                return WebSocketResult.Fail<WhiteBitMarginBalance[]>(result);
+                return QueryResult.Fail<WhiteBitMarginBalance[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return WebSocketResult.Ok(result, result.Data.Values.ToArray());
+            return QueryResult.Ok(result, result.Data.Values.ToArray());
         }
 
         /// <inheritdoc />
@@ -357,7 +357,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Open Orders
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitOrders>(
                 "ordersPending_request",
@@ -379,7 +379,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Closed Orders
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitClosedOrders>(
                 "ordersExecuted_request",
@@ -405,7 +405,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region User Trades
 
         /// <inheritdoc />
-        public async Task<WebSocketResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<QueryResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitUserTrades>(
                 "deals_request",
@@ -516,7 +516,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
         #endregion
 
-        private async Task<WebSocketResult<T>> QueryAsync<T>(string method, bool auth, CancellationToken ct, params object[] parameters)
+        private async Task<QueryResult<T>> QueryAsync<T>(string method, bool auth, CancellationToken ct, params object[] parameters)
         {
             var query = new WhiteBitQuery<T>(this, new WhiteBitSocketRequest
             {
@@ -527,9 +527,9 @@ namespace WhiteBit.Net.Clients.V4Api
 
             var result = await QueryAsync(BaseAddress.AppendPath("ws"), query, ct).ConfigureAwait(false);
             if (!result.Success)
-                return WebSocketResult.Fail<T>(result);
+                return QueryResult.Fail<T>(result);
 
-            return WebSocketResult.Ok(result, result.Data.Result);
+            return QueryResult.Ok(result, result.Data.Result);
         }
 
         /// <inheritdoc />

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
@@ -52,7 +52,7 @@ namespace WhiteBit.Net.Clients.V4Api
         /// ctor
         /// </summary>
         internal WhiteBitSocketClientV4Api(ILogger logger, WhiteBitSocketOptions options) :
-            base(logger, options.Environment.SocketClientAddress!, options, options.V4Options)
+            base(logger, WhiteBitExchange.ExchangeName, options.Environment.SocketClientAddress!, options, options.V4Options)
         {
             RateLimiter = WhiteBitExchange.RateLimiter.WhiteBitSocket;
             AllowTopicsOnTheSameConnection = false;
@@ -87,7 +87,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Trades
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitSocketTrade[]>(
                 "trades_request",
@@ -99,11 +99,11 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default)
             => await SubscribeToTradeUpdatesAsync([symbol], onMessage, ct).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitTradeUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -129,22 +129,25 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Last Price
 
         /// <inheritdoc />
-        public async Task<CallResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default)
+        public async Task<WebSocketResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default)
         {
             var result = await QueryAsync<decimal?>(
                 "lastprice_request",
                 false,
                 ct,
                 symbol).ConfigureAwait(false);
-            return result.As(result.Data ?? default);
+            if (!result.Success)
+                return WebSocketResult.Fail<decimal>(result);
+
+            return WebSocketResult.Ok(result, result.Data ?? default);
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(string symbol, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(string symbol, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default)
             => await SubscribeToLastPriceUpdatesAsync([symbol], onMessage, ct).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitLastPriceUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -165,7 +168,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Ticker
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitSocketTicker>(
                 "market_request",
@@ -176,11 +179,11 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default)
             => await SubscribeToTickerUpdatesAsync([symbol], onMessage, ct).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitTickerUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -201,7 +204,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Book Ticker
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitBookTickerUpdate[]>>((receiveTime, originalData, invocations, data) =>
             {
@@ -223,7 +226,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitBookTickerUpdate[]>>((receiveTime, originalData, invocations, data) =>
             {
@@ -249,7 +252,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Kline
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitKlineUpdate[]>(
                 "candles_request",
@@ -262,7 +265,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<WhiteBitKlineUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<WhiteBitKlineUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new WhiteBitKlineSubscription(_logger, this, symbol, interval, onMessage);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
@@ -273,7 +276,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Order book
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default)
         {
             depth.ValidateIntBetween(nameof(depth), 0, 100);
 
@@ -287,7 +290,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, Action<DataEvent<WhiteBitBookUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, Action<DataEvent<WhiteBitBookUpdate>> onMessage, CancellationToken ct = default)
         {
             depth.ValidateIntValues(nameof(depth), 1, 5, 10, 20, 30, 50, 100);
 
@@ -300,24 +303,24 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Spot Balances
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default)
         {
             var result = await QueryAsync<Dictionary<string, WhiteBitTradeBalance>>(
                 "balanceSpot_request",
                 true,
                 ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.As<WhiteBitTradeBalance[]>(default);
+            if (!result.Success)
+                return WebSocketResult.Fail<WhiteBitTradeBalance[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return result.As<WhiteBitTradeBalance[]>(result.Data.Values.ToArray());
+            return WebSocketResult.Ok(result, result.Data.Values.ToArray());
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSpotBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<Dictionary<string, WhiteBitTradeBalance>>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSpotBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<Dictionary<string, WhiteBitTradeBalance>>> onMessage, CancellationToken ct = default)
         {
             var subscription = new WhiteBitSpotBalanceSubscription(_logger, this, assets.ToArray(), onMessage);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
@@ -327,24 +330,24 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Margin Balances
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default)
         {
             var result = await QueryAsync<Dictionary<string, WhiteBitMarginBalance>>(
                 "balanceMargin_request",
                 true,
                 ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.As<WhiteBitMarginBalance[]>(default);
+            if (!result.Success)
+                return WebSocketResult.Fail<WhiteBitMarginBalance[]>(result);
 
             foreach (var item in result.Data)
                 item.Value.Asset = item.Key;
 
-            return result.As<WhiteBitMarginBalance[]>(result.Data.Values.ToArray());
+            return WebSocketResult.Ok(result, result.Data.Values.ToArray());
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToMarginBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<WhiteBitMarginBalance[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToMarginBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<WhiteBitMarginBalance[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new WhiteBitMarginBalanceSubscription(_logger, this, assets.ToArray(), onMessage);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
@@ -354,7 +357,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Open Orders
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitOrders>(
                 "ordersPending_request",
@@ -366,7 +369,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitOrderUpdate>> onOrderMessage, Action<DataEvent<WhiteBitOtoOrderUpdate>>? onOtoOrdersMessage = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitOrderUpdate>> onOrderMessage, Action<DataEvent<WhiteBitOtoOrderUpdate>>? onOtoOrdersMessage = null, CancellationToken ct = default)
         {
             var subscription = new WhiteBitOpenOrderSubscription(_logger, this, symbols.ToArray(), onOrderMessage, onOtoOrdersMessage);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
@@ -376,7 +379,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Closed Orders
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitClosedOrders>(
                 "ordersExecuted_request",
@@ -392,7 +395,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToClosedOrderUpdatesAsync(IEnumerable<string> symbols, ClosedOrderFilter filter, Action<DataEvent<WhiteBitClosedOrder[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToClosedOrderUpdatesAsync(IEnumerable<string> symbols, ClosedOrderFilter filter, Action<DataEvent<WhiteBitClosedOrder[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new WhiteBitClosedOrderSubscription(_logger, this, symbols.ToArray(), (int)filter, onMessage);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
@@ -402,7 +405,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region User Trades
 
         /// <inheritdoc />
-        public async Task<CallResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             return await QueryAsync<WhiteBitUserTrades>(
                 "deals_request",
@@ -414,7 +417,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitUserTradeUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitUserTradeUpdate>> onMessage, CancellationToken ct = default)
         {
             var subscription = new WhiteBitUserTradeSubscription(_logger, this, symbols.ToArray(), onMessage);
             return await SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct).ConfigureAwait(false);
@@ -424,7 +427,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Positions
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<WhiteBitPositionsUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<WhiteBitPositionsUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitPositionsUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -448,7 +451,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Borrow
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBorrowUpdatesAsync(Action<DataEvent<WhiteBitBorrow>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBorrowUpdatesAsync(Action<DataEvent<WhiteBitBorrow>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitBorrow>>((receiveTime, originalData, invocations, data) =>
             {
@@ -471,7 +474,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Account Borrow Events
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToAccountMarginPositionEventUpdatesAsync(Action<DataEvent<WhiteBitAccountMarginPositionUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToAccountMarginPositionEventUpdatesAsync(Action<DataEvent<WhiteBitAccountMarginPositionUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitAccountMarginPositionUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -493,7 +496,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #region Account Borrow Events
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToAccountBorrowEventUpdatesAsync(Action<DataEvent<WhiteBitAccountBorrowUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToAccountBorrowEventUpdatesAsync(Action<DataEvent<WhiteBitAccountBorrowUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, WhiteBitSocketUpdate<WhiteBitAccountBorrowUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -513,7 +516,7 @@ namespace WhiteBit.Net.Clients.V4Api
         }
         #endregion
 
-        private async Task<CallResult<T>> QueryAsync<T>(string method, bool auth, CancellationToken ct, params object[] parameters)
+        private async Task<WebSocketResult<T>> QueryAsync<T>(string method, bool auth, CancellationToken ct, params object[] parameters)
         {
             var query = new WhiteBitQuery<T>(this, new WhiteBitSocketRequest
             {
@@ -523,14 +526,14 @@ namespace WhiteBit.Net.Clients.V4Api
             }, auth);
 
             var result = await QueryAsync(BaseAddress.AppendPath("ws"), query, ct).ConfigureAwait(false);
-            return result.As<T>(result.Data == null ? default : result.Data.Result);
+            return WebSocketResult.Ok(result, result.Data == null ? default : result.Data.Result);
         }
 
         /// <inheritdoc />
         protected override async Task<Query?> GetAuthenticationRequestAsync(SocketConnection connection)
         {
             var token = await GetTokenAsync().ConfigureAwait(false);
-            if (!token)
+            if (!token.Success)
                 return null;
 
             return new WhiteBitQuery<WhiteBitSubscribeResponse>(this, new WhiteBitSocketRequest
@@ -544,16 +547,16 @@ namespace WhiteBit.Net.Clients.V4Api
             }, false);
         }
 
-        private async Task<CallResult<string>> GetTokenAsync()
+        private async Task<WebSocketResult<string>> GetTokenAsync()
         {
             if (ApiCredentials == null)
-                return new CallResult<string>(new NoApiCredentialsError());
+                return WebSocketResult.Fail<string>(ExchangeName, new NoApiCredentialsError());
 
             if (_tokenCache.TryGetValue(ApiCredentials.Key, out var token) && token.Expire > DateTime.UtcNow)
-                return new CallResult<string>(token.Token);
+                return new WebSocketResult<string>(ExchangeName, token.Token, null);
 
             if (ClientOptions.Environment.Name == "UnitTest")
-                return new CallResult<string>("123");
+                return new WebSocketResult<string>(ExchangeName, "123", null);
 
             _logger.LogDebug("Requesting websocket token");
             var restClient = new WhiteBitRestClient(x =>
@@ -563,14 +566,14 @@ namespace WhiteBit.Net.Clients.V4Api
             });
 
             var result = await ((WhiteBitRestClientV4ApiAccount)restClient.V4Api.Account).GetWebsocketTokenAsync().ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
             {
                 _logger.LogWarning("Failed to retrieve websocket token: {Error}", result.Error);
-                return result.As<string>(default);
+                return WebSocketResult.Fail<string>(ExchangeName, result.Error!);
             }
 
             _tokenCache[ApiCredentials.Key] = new CachedToken { Token = result.Data, Expire = DateTime.UtcNow.AddSeconds(60) };
-            return result.As<string>(result.Data);
+            return new WebSocketResult<string>(ExchangeName, result.Data, null);
         }
 
         private class CachedToken

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4Api.cs
@@ -45,14 +45,13 @@ namespace WhiteBit.Net.Clients.V4Api
         protected override ErrorMapping ErrorMapping => WhiteBitErrors.SocketErrors;
         #endregion
 
-
         #region constructor/destructor
 
         /// <summary>
         /// ctor
         /// </summary>
-        internal WhiteBitSocketClientV4Api(ILogger logger, WhiteBitSocketOptions options) :
-            base(logger, WhiteBitExchange.ExchangeName, options.Environment.SocketClientAddress!, options, options.V4Options)
+        internal WhiteBitSocketClientV4Api(ILoggerFactory? loggerFactory, WhiteBitSocketOptions options) :
+            base(loggerFactory, WhiteBitExchange.ExchangeName, options.Environment.SocketClientAddress!, options, options.V4Options)
         {
             RateLimiter = WhiteBitExchange.RateLimiter.WhiteBitSocket;
             AllowTopicsOnTheSameConnection = false;

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
@@ -25,7 +25,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(WhiteBitExchange.Metadata, this);
 
         #region Balance client
         SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchange, true)
@@ -105,7 +105,7 @@ namespace WhiteBit.Net.Clients.V4Api
             var result = await SubscribeToBookTickerUpdatesAsync(symbol, update =>
             {
                 handler(update.ToType(new SharedBookTicker(
-                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol),
                     update.Data.Symbol,
                     update.Data.BestAskPrice,
                     update.Data.BestAskQuantity,
@@ -167,7 +167,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(
-                new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.Ticker.LastPrice, update.Data.Ticker.HighPrice, update.Data.Ticker.LowPrice, update.Data.Ticker.Volume, update.Data.Ticker.OpenPrice == 0 ? null : Math.Round(update.Data.Ticker.ClosePrice / update.Data.Ticker.OpenPrice * 100 - 100, 2))
+                new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol), update.Data.Symbol, update.Data.Ticker.LastPrice, update.Data.Ticker.HighPrice, update.Data.Ticker.LowPrice, update.Data.Ticker.Volume, update.Data.Ticker.OpenPrice == 0 ? null : Math.Round(update.Data.Ticker.ClosePrice / update.Data.Ticker.OpenPrice * 100 - 100, 2))
                 {
                     QuoteVolume = update.Data.Ticker.QuoteVolume
                 })), ct).ConfigureAwait(false);
@@ -197,7 +197,7 @@ namespace WhiteBit.Net.Clients.V4Api
                         return;
 
                     handler(update.ToType<SharedTrade[]>(update.Data.Trades.Select(x => 
-                    new SharedTrade(ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol), update.Data.Symbol, x.Quantity, x.Price, x.Timestamp)
+                    new SharedTrade(ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol), update.Data.Symbol, x.Quantity, x.Price, x.Timestamp)
                     {
                         Side = x.Side == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
                     } ).ToArray()));
@@ -249,7 +249,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
                     handler(update.ToType<SharedUserTrade[]>([
                         new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol),
                             update.Data.Symbol,
                             update.Data.OrderId.ToString(),
                             update.Data.Id.ToString(),
@@ -313,7 +313,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
                     handler(update.ToType<SharedSpotOrder[]>(new[] {
                         new SharedSpotOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Order.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Order.Symbol),
                             update.Data.Order.Symbol,
                             update.Data.Order.OrderId.ToString(),
                             ParseOrderType(update.Data.Order.OrderType, update.Data.Order.PostOnly),
@@ -355,7 +355,7 @@ namespace WhiteBit.Net.Clients.V4Api
                     if (update.UpdateType == SocketUpdateType.Snapshot)
                         return;
 
-                    handler(update.ToType<SharedPosition[]>(update.Data.Records.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.Quantity), x.UpdateTime)
+                    handler(update.ToType<SharedPosition[]>(update.Data.Records.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), x.Symbol, Math.Abs(x.Quantity), x.UpdateTime)
                     {
                         AverageOpenPrice = x.BasePrice,
                         PositionMode = SharedPositionMode.OneWay,
@@ -417,7 +417,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
                     handler(update.ToType<SharedFuturesOrder[]>(new[] {
                         new SharedFuturesOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Order.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Order.Symbol),
                             update.Data.Order.Symbol,
                             update.Data.Order.OrderId.ToString(),
                             ParseOrderType(update.Data.Order.OrderType, update.Data.Order.PostOnly),

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
@@ -19,16 +19,16 @@ namespace WhiteBit.Net.Clients.V4Api
         private const string _exchange = "WhiteBit";
         private const string _topicSpotId = "WhiteBitSpot";
         private const string _topicFuturesId = "WhiteBitFutures";
-        public string Exchange => _exchange;
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear };
         public TradingMode[] SupportedFuturesModes => new[] { TradingMode.PerpetualLinear };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchange, true)
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchange, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -43,7 +43,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
             if (request.TradingMode == null || request.TradingMode == TradingMode.Spot)
             {
-                var assets = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
+                var assets = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
                 if (assets == null)
                 {
                     // request all assets
@@ -66,7 +66,7 @@ namespace WhiteBit.Net.Clients.V4Api
             }
             else
             {
-                var assets = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
+                var assets = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
                 if (assets == null)
                 {
                     // request all assets
@@ -94,7 +94,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchange, false);
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchange, false);
         async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
             var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
@@ -178,7 +178,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchange, false)
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchange, false)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 100
@@ -210,7 +210,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchange, true)
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchange, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -223,7 +223,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
-            var symbols = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "UserTradeSymbols");
+            var symbols = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "UserTradeSymbols");
             if (symbols == null)
             {
                 // request all symbols
@@ -270,7 +270,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient>(_exchange, false)
+        SubscribeSpotOrderOptions ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new SubscribeSpotOrderOptions(_exchange, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -283,7 +283,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
-            var symbols = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
+            var symbols = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
             if (symbols == null)
             {
                 // request all symbols
@@ -342,7 +342,7 @@ namespace WhiteBit.Net.Clients.V4Api
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest, IPositionSocketClient> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest, IPositionSocketClient>(_exchange, false);
+        SubscribePositionOptions IPositionSocketClient.SubscribePositionOptions { get; } = new SubscribePositionOptions(_exchange, false);
         async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
             var validationError = SharedClient.SubscribePositionOptions.ValidateRequest(request, this);
@@ -373,7 +373,7 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Futures Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient>(_exchange, false)
+        SubscribeFuturesOrderOptions IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new SubscribeFuturesOrderOptions(_exchange, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -386,7 +386,7 @@ namespace WhiteBit.Net.Clients.V4Api
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
-            var symbols = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
+            var symbols = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
             if (symbols == null)
             {
                 // request all symbols

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
@@ -60,7 +60,8 @@ namespace WhiteBit.Net.Clients.V4Api
 
                 var result = await SubscribeToSpotBalanceUpdatesAsync(
                     assets!,
-                    update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => new SharedBalance(x.Key, x.Value.Available, x.Value.Available + x.Value.Frozen)).ToArray())),
+                    update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x =>
+                        new SharedBalance(TradingMode.Spot, x.Key, x.Value.Available, x.Value.Available + x.Value.Frozen)).ToArray())),
                     ct: ct).ConfigureAwait(false);
                 return result;
             }
@@ -84,7 +85,9 @@ namespace WhiteBit.Net.Clients.V4Api
 
                 var result = await SubscribeToMarginBalanceUpdatesAsync(
                     assets,
-                    update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => new SharedBalance(x.Asset, x.AvailableWithoutBorrow, x.Balance)).ToArray())),
+                    update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => 
+                        new SharedBalance(
+                            SupportedFuturesModes, x.Asset, x.AvailableWithoutBorrow, x.Balance)).ToArray())),
                     ct: ct).ConfigureAwait(false);
                 return result;
             }

--- a/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitSocketClientV4ApiShared.cs
@@ -16,9 +16,10 @@ namespace WhiteBit.Net.Clients.V4Api
 {
     internal partial class WhiteBitSocketClientV4Api : IWhiteBitSocketClientV4ApiShared
     {
+        private const string _exchange = "WhiteBit";
         private const string _topicSpotId = "WhiteBitSpot";
         private const string _topicFuturesId = "WhiteBitFutures";
-        public string Exchange => "WhiteBit";
+        public string Exchange => _exchange;
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot, TradingMode.PerpetualLinear };
         public TradingMode[] SupportedFuturesModes => new[] { TradingMode.PerpetualLinear };
@@ -27,22 +28,22 @@ namespace WhiteBit.Net.Clients.V4Api
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(true)
+        EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchange, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("BalanceAssets", typeof(List<string>), "The assets to subscribe for updates", new List<string>{ "USDT", "ETH", "BTC" })
             }
         };
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
             if (request.TradingMode == null || request.TradingMode == TradingMode.Spot)
             {
-                var assets = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
+                var assets = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
                 if (assets == null)
                 {
                     // request all assets
@@ -51,8 +52,8 @@ namespace WhiteBit.Net.Clients.V4Api
                         x.Environment = ClientOptions.Environment;
                     });
                     var assetsResult = await client.V4Api.ExchangeData.GetAssetsAsync().ConfigureAwait(false);
-                    if (!assetsResult)
-                        return new ExchangeResult<UpdateSubscription>(Exchange, assetsResult.Error!);
+                    if (!assetsResult.Success)
+                        return WebSocketResult.Fail<UpdateSubscription>(Exchange, assetsResult.Error!);
 
                     assets = assetsResult.Data.Where(x => x.CanDeposit).Select(x => x.Asset).ToList();
                 }
@@ -61,11 +62,11 @@ namespace WhiteBit.Net.Clients.V4Api
                     assets!,
                     update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => new SharedBalance(x.Key, x.Value.Available, x.Value.Available + x.Value.Frozen)).ToArray())),
                     ct: ct).ConfigureAwait(false);
-                return new ExchangeResult<UpdateSubscription>(Exchange, result);
+                return result;
             }
             else
             {
-                var assets = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
+                var assets = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "BalanceAssets");
                 if (assets == null)
                 {
                     // request all assets
@@ -75,8 +76,8 @@ namespace WhiteBit.Net.Clients.V4Api
                         x.ApiCredentials = (WhiteBitCredentials?)AuthenticationProvider!.ApiCredentials.Copy();
                     });
                     var assetsResult = await client.V4Api.Account.GetCollateralBalancesAsync().ConfigureAwait(false);
-                    if (!assetsResult)
-                        return new ExchangeResult<UpdateSubscription>(Exchange, assetsResult.Error!);
+                    if (!assetsResult.Success)
+                        return WebSocketResult.Fail<UpdateSubscription>(Exchange, assetsResult.Error!);
 
                     assets = assetsResult.Data.Select(x => x.Key).Distinct().ToList();
                 }
@@ -85,7 +86,7 @@ namespace WhiteBit.Net.Clients.V4Api
                     assets,
                     update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => new SharedBalance(x.Asset, x.AvailableWithoutBorrow, x.Balance)).ToArray())),
                     ct: ct).ConfigureAwait(false);
-                return new ExchangeResult<UpdateSubscription>(Exchange, result);
+                return result;
             }
         }
 
@@ -93,12 +94,12 @@ namespace WhiteBit.Net.Clients.V4Api
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchange, false);
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await SubscribeToBookTickerUpdatesAsync(symbol, update =>
@@ -112,13 +113,13 @@ namespace WhiteBit.Net.Clients.V4Api
                     update.Data.BestBidQuantity)));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Kline client
-        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(false,
+        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(_exchange, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.ThreeMinutes,
             SharedKlineInterval.FiveMinutes,
@@ -132,16 +133,13 @@ namespace WhiteBit.Net.Clients.V4Api
             SharedKlineInterval.OneDay,
             SharedKlineInterval.OneWeek,
             SharedKlineInterval.OneMonth);
-        async Task<ExchangeResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
         {
-            var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
-
-            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
+            var interval = (Enums.KlineInterval)request.Interval;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await SubscribeToKlineUpdatesAsync(symbol, interval, update =>
             {
@@ -152,20 +150,20 @@ namespace WhiteBit.Net.Clients.V4Api
                     handler(update.ToType(new SharedKline(request.Symbol, symbol, item.OpenTime, item.ClosePrice, item.HighPrice, item.LowPrice, item.OpenPrice, item.Volume)));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions()
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchange)
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(
@@ -174,22 +172,22 @@ namespace WhiteBit.Net.Clients.V4Api
                     QuoteVolume = update.Data.Ticker.QuoteVolume
                 })), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false)
+        EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchange, false)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 100
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTradeUpdatesAsync(symbols, 
@@ -205,27 +203,27 @@ namespace WhiteBit.Net.Clients.V4Api
                     } ).ToArray()));
                 }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(true)
+        EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchange, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("UserTradeSymbols", typeof(List<string>), "The symbols to subscribe for updates", new List<string>{ "ETH_USDT", "ETH_PERP" })
             }
         };
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
-            var symbols = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "UserTradeSymbols");
+            var symbols = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "UserTradeSymbols");
             if (symbols == null)
             {
                 // request all symbols
@@ -234,8 +232,8 @@ namespace WhiteBit.Net.Clients.V4Api
                     x.Environment = ClientOptions.Environment;
                 });
                 var symbolsResult = await client.V4Api.ExchangeData.GetSymbolsAsync().ConfigureAwait(false);
-                if (!symbolsResult)
-                    return new ExchangeResult<UpdateSubscription>(Exchange, symbolsResult.Error!);
+                if (!symbolsResult.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(Exchange, symbolsResult.Error!);
 
                 symbols = symbolsResult.Data.Select(x => x.Name).ToList();
             }
@@ -265,27 +263,27 @@ namespace WhiteBit.Net.Clients.V4Api
                     }]));
                 }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest>(false)
+        EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient>(_exchange, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("OrderSymbols", typeof(List<string>), "The symbols to subscribe for updates", new List<string>{ "ETH_USDT" })
             }
         };
-        async Task<ExchangeResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(Exchange, request, TradingMode.Spot, [TradingMode.Spot]);
+            var validationError = SharedClient.SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
-            var symbols = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
+            var symbols = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
             if (symbols == null)
             {
                 // request all symbols
@@ -294,8 +292,8 @@ namespace WhiteBit.Net.Clients.V4Api
                     x.Environment = ClientOptions.Environment;
                 });
                 var symbolsResult = await client.V4Api.ExchangeData.GetSymbolsAsync().ConfigureAwait(false);
-                if (!symbolsResult)
-                    return new ExchangeResult<UpdateSubscription>(Exchange, symbolsResult.Error!);
+                if (!symbolsResult.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(Exchange, symbolsResult.Error!);
 
                 symbols = symbolsResult.Data.Where(x => x.SymbolType == SymbolType.Spot).Select(x => x.Name).ToList();
             }
@@ -339,17 +337,17 @@ namespace WhiteBit.Net.Clients.V4Api
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
+        EndpointOptions<SubscribePositionRequest, IPositionSocketClient> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest, IPositionSocketClient>(_exchange, false);
+        async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
             var result = await SubscribeToPositionUpdatesAsync(
                 update =>
@@ -368,27 +366,27 @@ namespace WhiteBit.Net.Clients.V4Api
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Futures Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest>(false)
+        EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient>(_exchange, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("OrderSymbols", typeof(List<string>), "The symbols to subscribe for updates", new List<string>{ "ETH_PERP" })
             }
         };
-        async Task<ExchangeResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedFuturesModes);
+            var validationError = SharedClient.SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(Exchange, validationError);
 
-            var symbols = ExchangeParameters.GetValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
+            var symbols = ExchangeParameters.GetProcessValue<List<string>>(request.ExchangeParameters, Exchange, "OrderSymbols");
             if (symbols == null)
             {
                 // request all symbols
@@ -397,8 +395,8 @@ namespace WhiteBit.Net.Clients.V4Api
                     x.Environment = ClientOptions.Environment;
                 });
                 var symbolsResult = await client.V4Api.ExchangeData.GetSymbolsAsync().ConfigureAwait(false);
-                if (!symbolsResult)
-                    return new ExchangeResult<UpdateSubscription>(Exchange, symbolsResult.Error!);
+                if (!symbolsResult.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(Exchange, symbolsResult.Error!);
 
                 symbols = symbolsResult.Data.Where(x => x.SymbolType == SymbolType.Futures).Select(x => x.Name).ToList();
             }
@@ -443,7 +441,7 @@ namespace WhiteBit.Net.Clients.V4Api
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 

--- a/WhiteBit.Net/Clients/WhiteBitRestClient.cs
+++ b/WhiteBit.Net/Clients/WhiteBitRestClient.cs
@@ -45,7 +45,7 @@ namespace WhiteBit.Net.Clients
         {
             Initialize(options.Value);
 
-            V4Api = AddApiClient(new WhiteBitRestClientV4Api(_logger, httpClient, options.Value));
+            V4Api = AddApiClient(new WhiteBitRestClientV4Api(loggerFactory, httpClient, options.Value));
         }
 
         #endregion

--- a/WhiteBit.Net/Clients/WhiteBitSocketClient.cs
+++ b/WhiteBit.Net/Clients/WhiteBitSocketClient.cs
@@ -43,7 +43,7 @@ namespace WhiteBit.Net.Clients
         {
             Initialize(options.Value);
 
-            V4Api = AddApiClient(new WhiteBitSocketClientV4Api(_logger, options.Value));
+            V4Api = AddApiClient(new WhiteBitSocketClientV4Api(loggerFactory, options.Value));
         }
         #endregion
 

--- a/WhiteBit.Net/Clients/WhiteBitUserClientProvider.cs
+++ b/WhiteBit.Net/Clients/WhiteBitUserClientProvider.cs
@@ -6,22 +6,22 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Concurrent;
 using System.Net.Http;
+using CryptoExchange.Net.Clients;
 
 namespace WhiteBit.Net.Clients
 {
     /// <inheritdoc />
-    public class WhiteBitUserClientProvider : IWhiteBitUserClientProvider
+    public class WhiteBitUserClientProvider : UserClientProvider<
+        IWhiteBitRestClient,
+        IWhiteBitSocketClient,
+        WhiteBitRestOptions,
+        WhiteBitSocketOptions,
+        WhiteBitCredentials,
+        WhiteBitEnvironment
+        >, IWhiteBitUserClientProvider
     {
-        private ConcurrentDictionary<string, IWhiteBitRestClient> _restClients = new ConcurrentDictionary<string, IWhiteBitRestClient>();
-        private ConcurrentDictionary<string, IWhiteBitSocketClient> _socketClients = new ConcurrentDictionary<string, IWhiteBitSocketClient>();
-
-        private readonly IOptions<WhiteBitRestOptions> _restOptions;
-        private readonly IOptions<WhiteBitSocketOptions> _socketOptions;
-        private readonly HttpClient _httpClient;
-        private readonly ILoggerFactory? _loggerFactory;
-
         /// <inheritdoc />
-        public string ExchangeName => WhiteBitExchange.ExchangeName;
+        public override string ExchangeName => WhiteBitExchange.ExchangeName;
 
         /// <summary>
         /// ctor
@@ -40,97 +40,15 @@ namespace WhiteBit.Net.Clients
             ILoggerFactory? loggerFactory,
             IOptions<WhiteBitRestOptions> restOptions,
             IOptions<WhiteBitSocketOptions> socketOptions)
+            : base(httpClient, loggerFactory, restOptions, socketOptions)
         {
-            _httpClient = httpClient ?? new HttpClient();
-            _httpClient.Timeout = restOptions.Value.RequestTimeout;
-            _loggerFactory = loggerFactory;
-            _restOptions = restOptions;
-            _socketOptions = socketOptions;
         }
 
         /// <inheritdoc />
-        public void InitializeUserClient(string userIdentifier, WhiteBitCredentials credentials, WhiteBitEnvironment? environment = null)
-        {
-            CreateRestClient(userIdentifier, credentials, environment);
-            CreateSocketClient(userIdentifier, credentials, environment);
-        }
-
+        protected override IWhiteBitRestClient ConstructRestClient(HttpClient client, ILoggerFactory? loggerFactory, IOptions<WhiteBitRestOptions> options) 
+            => new WhiteBitRestClient(client, loggerFactory, options);
         /// <inheritdoc />
-        public void ClearUserClients(string userIdentifier)
-        {
-            _restClients.TryRemove(userIdentifier, out _);
-            _socketClients.TryRemove(userIdentifier, out _);
-        }
-
-        /// <inheritdoc />
-        public IWhiteBitRestClient GetRestClient(string userIdentifier, WhiteBitCredentials? credentials = null, WhiteBitEnvironment? environment = null)
-        {
-            if (!_restClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateRestClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        /// <inheritdoc />
-        public IWhiteBitSocketClient GetSocketClient(string userIdentifier, WhiteBitCredentials? credentials = null, WhiteBitEnvironment? environment = null)
-        {
-            if (!_socketClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateSocketClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        private IWhiteBitRestClient CreateRestClient(string userIdentifier, WhiteBitCredentials? credentials, WhiteBitEnvironment? environment)
-        {
-            var clientRestOptions = SetRestEnvironment(environment);
-            var client = new WhiteBitRestClient(_httpClient, _loggerFactory, clientRestOptions);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _restClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IWhiteBitSocketClient CreateSocketClient(string userIdentifier, WhiteBitCredentials? credentials, WhiteBitEnvironment? environment)
-        {
-            var clientSocketOptions = SetSocketEnvironment(environment);
-            var client = new WhiteBitSocketClient(clientSocketOptions!, _loggerFactory);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _socketClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOptions<WhiteBitRestOptions> SetRestEnvironment(WhiteBitEnvironment? environment)
-        {
-            if (environment == null)
-                return _restOptions;
-
-            var newRestClientOptions = new WhiteBitRestOptions();
-            var restOptions = _restOptions.Value.Set(newRestClientOptions);
-            newRestClientOptions.Environment = environment;
-            return Options.Create(newRestClientOptions);
-        }
-
-        private IOptions<WhiteBitSocketOptions> SetSocketEnvironment(WhiteBitEnvironment? environment)
-        {
-            if (environment == null)
-                return _socketOptions;
-
-            var newSocketClientOptions = new WhiteBitSocketOptions();
-            var restOptions = _socketOptions.Value.Set(newSocketClientOptions);
-            newSocketClientOptions.Environment = environment;
-            return Options.Create(newSocketClientOptions);
-        }
-
-        private static T ApplyOptionsDelegate<T>(Action<T>? del) where T : new()
-        {
-            var opts = new T();
-            del?.Invoke(opts);
-            return opts;
-        }
+        protected override IWhiteBitSocketClient ConstructSocketClient(ILoggerFactory? loggerFactory, IOptions<WhiteBitSocketOptions> options)
+            => new WhiteBitSocketClient(options, loggerFactory);
     }
 }

--- a/WhiteBit.Net/Converters/WhiteBitSourceGenerationContext.cs
+++ b/WhiteBit.Net/Converters/WhiteBitSourceGenerationContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using CryptoExchange.Net.Objects;
 using WhiteBit.Net.Enums;
 using WhiteBit.Net.Objects.Internal;
 using WhiteBit.Net.Objects.Models;
@@ -17,6 +18,7 @@ namespace WhiteBit.Net.Converters
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitOrderBook>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<Dictionary<string, WhiteBitTradeBalance>>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<Dictionary<string, WhiteBitMarginBalance>>))]
+    [JsonSerializable(typeof(Parameters))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitOrders>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitClosedOrders>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitUserTrades>))]

--- a/WhiteBit.Net/Converters/WhiteBitSourceGenerationContext.cs
+++ b/WhiteBit.Net/Converters/WhiteBitSourceGenerationContext.cs
@@ -19,6 +19,7 @@ namespace WhiteBit.Net.Converters
     [JsonSerializable(typeof(WhiteBitSocketResponse<Dictionary<string, WhiteBitTradeBalance>>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<Dictionary<string, WhiteBitMarginBalance>>))]
     [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(Parameters[]))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitOrders>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitClosedOrders>))]
     [JsonSerializable(typeof(WhiteBitSocketResponse<WhiteBitUserTrades>))]

--- a/WhiteBit.Net/Interfaces/Clients/IWhiteBitUserClientProvider.cs
+++ b/WhiteBit.Net/Interfaces/Clients/IWhiteBitUserClientProvider.cs
@@ -22,6 +22,11 @@ namespace WhiteBit.Net.Interfaces.Clients
         public void ClearUserClients(string userIdentifier);
 
         /// <summary>
+        /// Clear all client from the cache
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Get the Rest client for a specific user. In case the client does not exist yet it will be created and the <paramref name="credentials"/> should be provided, unless <see cref="InitializeUserClient" /> has been called prior for this user.
         /// </summary>
         /// <param name="userIdentifier">The identifier for user</param>

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiAccount.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiAccount.cs
@@ -23,7 +23,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitMainBalance[]>> GetMainBalancesAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitMainBalance[]>> GetMainBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get deposit address
@@ -37,7 +37,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="asset">["<c>ticker</c>"] The asset</param>
         /// <param name="network">["<c>network</c>"] Network to use</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitDepositAddressInfo>> GetDepositAddressAsync(string asset, string? network = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitDepositAddressInfo>> GetDepositAddressAsync(string asset, string? network = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get spot trading balances
@@ -50,7 +50,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="asset">["<c>ticker</c>"] Filter by asset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(string? asset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(string? asset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get fiat deposit url, note that his endpoint is not available by default and has to be activated for you by WhiteBit support
@@ -77,7 +77,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="customerZipCode">["<c>customer.address.zipCode</c>"] Customer zip code</param>
         /// <param name="customerCountryCode">["<c>customer.address.countryCode</c>"] Customer country code</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitDepositUrl>> GetFiatDepositAddressAsync(string asset, string provider, decimal quantity, string clientOrderId, string? successLink = null, string? failureLink = null, string? returnLink = null, string? customerFirstName = null, string? customerLastName = null, string? customerEmail = null, string? customerAddressLine1 = null, string? customerAddressLine2 = null, string? customerCity = null, string? customerZipCode = null, string? customerCountryCode = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitDepositUrl>> GetFiatDepositAddressAsync(string asset, string provider, decimal quantity, string clientOrderId, string? successLink = null, string? failureLink = null, string? returnLink = null, string? customerFirstName = null, string? customerLastName = null, string? customerEmail = null, string? customerAddressLine1 = null, string? customerAddressLine2 = null, string? customerCity = null, string? customerZipCode = null, string? customerCountryCode = null, CancellationToken ct = default);
 
         /// <summary>
         /// Withdraw fiat or crypto
@@ -105,7 +105,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="beneficiaryPhone">["<c>beneficiary.phone</c>"] Beneficiary phone number</param>
         /// <param name="beneficiaryEmail">["<c>beneficiary.email</c>"] Beneficiary email</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> WithdrawAsync(string asset, decimal quantity, string address, string uniqueId, bool deductFeeFromOutput, string? memo = null, string? provider = null, string? network = null, bool? partialEnable = null, string? beneficiaryFirstName = null, string? beneficiaryLastName = null, string? beneficiaryTin = null, string? beneficiaryPhone = null, string? beneficiaryEmail = null, CancellationToken ct = default);
+        Task<HttpResult> WithdrawAsync(string asset, decimal quantity, string address, string uniqueId, bool deductFeeFromOutput, string? memo = null, string? provider = null, string? network = null, bool? partialEnable = null, string? beneficiaryFirstName = null, string? beneficiaryLastName = null, string? beneficiaryTin = null, string? beneficiaryPhone = null, string? beneficiaryEmail = null, CancellationToken ct = default);
         
         /// <summary>
         /// Transfer between accounts
@@ -121,7 +121,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="asset">["<c>ticker</c>"] The asset, for example `ETH`</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity to transfer</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> TransferAsync(AccountType fromAccount, AccountType toAccount, string asset, decimal quantity, CancellationToken ct = default);
+        Task<HttpResult> TransferAsync(AccountType fromAccount, AccountType toAccount, string asset, decimal quantity, CancellationToken ct = default);
 
         /// <summary>
         /// Get deposit/withdrawal history
@@ -141,7 +141,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitDepositWithdrawals>> GetDepositWithdrawalHistoryAsync(TransactionType? type = null, string? asset = null, string? address = null, string? memo = null, string? addresses = null, string? uniqueId = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitDepositWithdrawals>> GetDepositWithdrawalHistoryAsync(TransactionType? type = null, string? asset = null, string? address = null, string? memo = null, string? addresses = null, string? uniqueId = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Create a new deposit address, note that his endpoint is not available by default and has to be activated for you by WhiteBit support
@@ -156,7 +156,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="network">["<c>network</c>"] Asset network</param>
         /// <param name="addressType">["<c>type</c>"] Address type for BTC/LTC: p2sh-segwit, bech32</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitDepositAddressInfo>> CreateDepositAddressAsync(string asset, string? network = null, string? addressType = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitDepositAddressInfo>> CreateDepositAddressAsync(string asset, string? network = null, string? addressType = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get deposit/withdrawal settings
@@ -168,7 +168,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitDepositWithdrawalSetting[]>> GetDepositWithdrawalSettingsAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitDepositWithdrawalSetting[]>> GetDepositWithdrawalSettingsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get mining rewards history
@@ -185,7 +185,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitMiningRewards>> GetMiningRewardHistoryAsync(string? accountName = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitMiningRewards>> GetMiningRewardHistoryAsync(string? accountName = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get collateral balances
@@ -198,7 +198,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="asset">["<c>ticker</c>"] Filter by asset, for example `ETH`</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, decimal>>> GetCollateralBalancesAsync(string? asset = null, CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, decimal>>> GetCollateralBalancesAsync(string? asset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get collateral balance summary
@@ -210,7 +210,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitCollateralSummary[]>> GetCollateralBalanceSummaryAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitCollateralSummary[]>> GetCollateralBalanceSummaryAsync(CancellationToken ct = default);
         
         /// <summary>
         /// Get collateral account summary
@@ -222,7 +222,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitCollateralAccountSummary>> GetCollateralAccountSummaryAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitCollateralAccountSummary>> GetCollateralAccountSummaryAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Asynchronously retrieves the account funding history for the specified trading pair.
@@ -242,9 +242,9 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] The optional maximum number of records to return. If not specified, a default limit is applied.</param>
         /// <param name="offset">["<c>offset</c>"] The optional offset for pagination. Specifies the number of records to skip before returning results.</param>
         /// <param name="ct">A cancellation token that can be used to cancel the asynchronous operation.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains a WebCallResult with the funding
+        /// <returns>A task that represents the asynchronous operation. The task result contains a HttpResult with the funding
         /// history records for the specified account and symbol.</returns>
-        Task<WebCallResult<WhiteBitAccountFundingHistories>> GetAccountFundingHistoryAsync(
+        Task<HttpResult<WhiteBitAccountFundingHistories>> GetAccountFundingHistoryAsync(
             string symbol,
             DateTime? startTime = null,
             DateTime? endTime = null,
@@ -263,7 +263,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="leverage">["<c>leverage</c>"] New leverage setting</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitLeverage>> SetAccountLeverageAsync(int leverage, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitLeverage>> SetAccountLeverageAsync(int leverage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the users trading fees
@@ -275,7 +275,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitTradingFees>> GetTradingFeesAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitTradingFees>> GetTradingFeesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get current hedge mode status
@@ -287,7 +287,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitHedgeMode>> GetHedgeModeAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitHedgeMode>> GetHedgeModeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Set hedge mode
@@ -300,7 +300,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="enableHedgeMode">["<c>hedgeMode</c>"] Hedge mode enabled or not</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitHedgeMode>> SetHedgeModeAsync(bool enableHedgeMode, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitHedgeMode>> SetHedgeModeAsync(bool enableHedgeMode, CancellationToken ct = default);
 
     }
 }

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiCodes.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiCodes.cs
@@ -24,7 +24,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="passphrase">Passphrase for applying the code</param>
         /// <param name="description">Description</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitCode>> CreateCodeAsync(string asset, decimal quantity, string? passphrase = null, string? description = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitCode>> CreateCodeAsync(string asset, decimal quantity, string? passphrase = null, string? description = null, CancellationToken ct = default);
 
         /// <summary>
         /// Apply a WhiteBit code
@@ -38,7 +38,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="code">The WhiteBit code</param>
         /// <param name="passphrase">Code passphrase</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitCodeResult>> ApplyCodeAsync(string code, string? passphrase = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitCodeResult>> ApplyCodeAsync(string code, string? passphrase = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get generated code history
@@ -52,7 +52,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitGeneratedCodes>> GetCreatedCodesAsync(int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitGeneratedCodes>> GetCreatedCodesAsync(int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get account code history
@@ -66,7 +66,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitGeneratedCodes>> GetCodeHistoryAsync(int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitGeneratedCodes>> GetCodeHistoryAsync(int? limit = null, int? offset = null, CancellationToken ct = default);
 
     }
 }

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiCollateralTrading.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiCollateralTrading.cs
@@ -43,7 +43,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="positionSide">["<c>positionSide</c>"] Position side, required when in hedge mode</param>
         /// <param name="reduceOnly">["<c>reduceOnly</c>"] Reduce only order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitCollateralOrder>> PlaceOrderAsync(
+        Task<HttpResult<WhiteBitCollateralOrder>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             NewOrderType type,
@@ -72,7 +72,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="symbol">["<c>market</c>"] Filter by symbol</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitPosition[]>> GetOpenPositionsAsync(string? symbol = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitPosition[]>> GetOpenPositionsAsync(string? symbol = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get position history
@@ -90,7 +90,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitPositionHistory[]>> GetPositionHistoryAsync(string? symbol = null, long? positionId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitPositionHistory[]>> GetPositionHistoryAsync(string? symbol = null, long? positionId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get open conditional orders
@@ -105,7 +105,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitConditionalOrdersResult>> GetOpenConditionalOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitConditionalOrdersResult>> GetOpenConditionalOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Place a new OCO order
@@ -126,7 +126,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="positionSide">["<c>positionSide</c>"] Position side, required when in hedge mode</param>
         /// <param name="reduceOnly">["<c>reduceOnly</c>"] Reduce only</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitOcoOrder>> PlaceOcoOrderAsync(
+        Task<HttpResult<WhiteBitOcoOrder>> PlaceOcoOrderAsync(
             string symbol,
             OrderSide orderSide,
             decimal quantity,
@@ -150,7 +150,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="symbol">["<c>market</c>"] The symbol, for example `ETH_PERP`</param>
         /// <param name="orderId">["<c>orderId</c>"] Order id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitOcoOrder>> CancelOcoOrderAsync(string symbol, long orderId, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitOcoOrder>> CancelOcoOrderAsync(string symbol, long orderId, CancellationToken ct = default);
         
         /// <summary>
         /// Cancel a conditional order
@@ -164,7 +164,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="symbol">["<c>market</c>"] The symbol, for example `ETH_PERP`</param>
         /// <param name="orderId">["<c>id</c>"] Order id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> CancelConditionalOrderAsync(string symbol, long orderId, CancellationToken ct = default);
+        Task<HttpResult> CancelConditionalOrderAsync(string symbol, long orderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an OTO order
@@ -178,7 +178,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="symbol">["<c>market</c>"] The symbol, for example `ETH_PERP`</param>
         /// <param name="orderId">["<c>otoId</c>"] Order id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> CancelOTOOrderAsync(string symbol, long orderId, CancellationToken ct = default);
+        Task<HttpResult> CancelOTOOrderAsync(string symbol, long orderId, CancellationToken ct = default);
 
     }
 }

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiConvert.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiConvert.cs
@@ -25,7 +25,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="quantity">["<c>amount</c>"] Quantity</param>
         /// <param name="fromOrToQuantity">["<c>direction</c>"] Whether the quantity is specified in the fromAsset or toAsset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitConvertEstimate>> GetConvertEstimateAsync(string fromAsset, string toAsset, decimal quantity, string fromOrToQuantity, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitConvertEstimate>> GetConvertEstimateAsync(string fromAsset, string toAsset, decimal quantity, string fromOrToQuantity, CancellationToken ct = default);
 
         /// <summary>
         /// Accept/confirm a convert estimate
@@ -38,7 +38,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="estimateId">["<c>quoteId</c>"] Quote/estimate id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitConvertResult>> ConfirmConvertAsync(string estimateId, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitConvertResult>> ConfirmConvertAsync(string estimateId, CancellationToken ct = default);
 
         /// <summary>
         /// Get convert history
@@ -57,7 +57,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitConvertHistory>> GetConvertHistoryAsync(string? fromAsset = null, string? toAsset = null, string? quoteId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitConvertHistory>> GetConvertHistoryAsync(string? fromAsset = null, string? toAsset = null, string? quoteId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
     }
 }

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiExchangeData.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiExchangeData.cs
@@ -23,7 +23,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
+        Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get symbols list
@@ -35,7 +35,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitSymbol[]>> GetSymbolsAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitSymbol[]>> GetSymbolsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get system/platform status
@@ -47,7 +47,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitSystemStatus>> GetSystemStatusAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitSystemStatus>> GetSystemStatusAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get tickers
@@ -59,7 +59,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitTicker[]>> GetTickersAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitTicker[]>> GetTickersAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get asset information
@@ -71,7 +71,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitAsset[]>> GetAssetsAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitAsset[]>> GetAssetsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get the order book for a symbol
@@ -86,7 +86,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] The order book depth, max 100</param>
         /// <param name="mergeLevel">["<c>level</c>"] Aggregation level</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int? limit = null, int? mergeLevel = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int? limit = null, int? mergeLevel = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the most recent 100 trades
@@ -100,7 +100,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="symbol">The symbol, for example `ETHUSDT`</param>
         /// <param name="side">["<c>type</c>"] Filter by trade side</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitTrade[]>> GetRecentTradesAsync(string symbol, OrderSide? side = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitTrade[]>> GetRecentTradesAsync(string symbol, OrderSide? side = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get withdrawal/deposit limits and fees
@@ -112,7 +112,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitDepositWithdraw>> GetDepositWithdrawalInfoAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitDepositWithdraw>> GetDepositWithdrawalInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get collateral symbols
@@ -124,7 +124,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<string[]>> GetCollateralSymbolsAsync(CancellationToken ct = default);
+        Task<HttpResult<string[]>> GetCollateralSymbolsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get futures symbols
@@ -136,7 +136,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitFuturesSymbol[]>> GetFuturesSymbolsAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitFuturesSymbol[]>> GetFuturesSymbolsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get funding rate history
@@ -147,7 +147,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitFundingHistory[]>> GetFundingHistoryAsync(
+        Task<HttpResult<WhiteBitFundingHistory[]>> GetFundingHistoryAsync(
             string symbol,
             DateTime? startTime = null,
             DateTime? endTime = null,

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiSubAccount.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiSubAccount.cs
@@ -26,7 +26,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="spotEnabled">["<c>permissions.spotEnabled</c>"] Whether spot trading is enabled</param>
         /// <param name="collateralEnabled">["<c>permissions.collateralEnabled</c>"] Whether collateral trading is enabled</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitSubAccount>> CreateSubAccountAsync(string alias, string? email = null, bool? shareKyc = null, string? spotEnabled = null, string? collateralEnabled = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitSubAccount>> CreateSubAccountAsync(string alias, string? email = null, bool? shareKyc = null, string? spotEnabled = null, string? collateralEnabled = null, CancellationToken ct = default);
         
         /// <summary>
         /// Delete a sub account
@@ -39,7 +39,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="id">["<c>id</c>"] Sub account id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> DeleteSubAccountAsync(string id, CancellationToken ct = default);
+        Task<HttpResult> DeleteSubAccountAsync(string id, CancellationToken ct = default);
 
         /// <summary>
         /// Edit a sub account
@@ -55,7 +55,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="spotEnabled">["<c>permissions.spotEnabled</c>"] Spot trading enabled</param>
         /// <param name="collateralEnabled">["<c>permissions.collateralEnabled</c>"] Collateral trading enabled</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> EditSubAccountAsync(string id, string alias, string spotEnabled, string collateralEnabled, CancellationToken ct = default);
+        Task<HttpResult> EditSubAccountAsync(string id, string alias, string spotEnabled, string collateralEnabled, CancellationToken ct = default);
 
         /// <summary>
         /// Get sub account list
@@ -70,7 +70,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitSubAccounts>> GetSubAccountsAsync(string? search = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitSubAccounts>> GetSubAccountsAsync(string? search = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Transfer to or from sub account
@@ -86,7 +86,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="asset">["<c>ticker</c>"] The asset, for example `ETH`</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> SubaccountTransferAsync(string subaccountId, SubTransferDirection direction, string asset, decimal quantity, CancellationToken ct = default);
+        Task<HttpResult> SubaccountTransferAsync(string subaccountId, SubTransferDirection direction, string asset, decimal quantity, CancellationToken ct = default);
 
         /// <summary>
         /// Block a sub account
@@ -99,7 +99,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="id">["<c>id</c>"] Sub account id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> BlockSubaccountAsync(string id, CancellationToken ct = default);
+        Task<HttpResult> BlockSubaccountAsync(string id, CancellationToken ct = default);
 
         /// <summary>
         /// Unblock a sub account
@@ -112,7 +112,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="id">["<c>id</c>"] Sub account id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> UnblockSubaccountAsync(string id, CancellationToken ct = default);
+        Task<HttpResult> UnblockSubaccountAsync(string id, CancellationToken ct = default);
 
         /// <summary>
         /// Get sub account balances
@@ -126,7 +126,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="id">["<c>id</c>"] Sub account id</param>
         /// <param name="asset">["<c>ticker</c>"] Asset name</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitSubBalances[]>> GetSubaccountBalancesAsync(string id, string? asset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitSubBalances[]>> GetSubaccountBalancesAsync(string id, string? asset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get sub account transfer history
@@ -138,7 +138,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitSubaccountTransferHistory>> GetSubaccountTransferHistoryAsync(CancellationToken ct = default);
+        Task<HttpResult<WhiteBitSubaccountTransferHistory>> GetSubaccountTransferHistoryAsync(CancellationToken ct = default);
 
     }
 }

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiTrading.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitRestClientV4ApiTrading.cs
@@ -44,7 +44,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="stpMode">["<c>stp</c>"] Self trade prevention mode</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<WhiteBitOrder>> PlaceSpotOrderAsync(
+        Task<HttpResult<WhiteBitOrder>> PlaceSpotOrderAsync(
             string symbol,
             OrderSide side,
             NewOrderType type,
@@ -70,7 +70,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="requests">["<c>orders</c>"] Orders to place, max 20</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult<WhiteBitOrderResponse>[]>> PlaceSpotMultipleOrdersAsync(
+        Task<HttpResult<CallResult<WhiteBitOrderResponse>[]>> PlaceSpotMultipleOrdersAsync(
             IEnumerable<WhiteBitOrderRequest> requests,
             CancellationToken ct = default);
 
@@ -87,7 +87,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="orderId">["<c>orderId</c>"] The order id, either this or `clientOrderId` has to be provided</param>
         /// <param name="clientOrderId">["<c>clientOrderId</c>"] The client order id, either this or `id` should be provided</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitOrder>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitOrder>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders
@@ -100,7 +100,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="requests">Order requests</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitCancelOrdersResult[]>> CancelOrdersAsync(IEnumerable<WhiteBitCancelRequest> requests, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitCancelOrdersResult[]>> CancelOrdersAsync(IEnumerable<WhiteBitCancelRequest> requests, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel all orders
@@ -114,7 +114,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="symbol">["<c>market</c>"] Filter by symbol</param>
         /// <param name="orderProductTypes">["<c>type</c>"] Filter by order product types</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> CancelAllOrdersAsync(string? symbol = null, IEnumerable<OrderProductType>? orderProductTypes = null, CancellationToken ct = default);
+        Task<HttpResult> CancelAllOrdersAsync(string? symbol = null, IEnumerable<OrderProductType>? orderProductTypes = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get list of currently open orders
@@ -131,7 +131,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitOrder[]>> GetOpenOrdersAsync(string? symbol = null, long? orderId = null, string? clientOrderId = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitOrder[]>> GetOpenOrdersAsync(string? symbol = null, long? orderId = null, string? clientOrderId = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get list of closed orders per symbol
@@ -151,7 +151,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="startTime">["<c>startDate</c>"] Filter by start time</param>
         /// <param name="endTime">["<c>endDate</c>"] Filter by end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, WhiteBitClosedOrder[]>>> GetClosedOrdersAsync(
+        Task<HttpResult<Dictionary<string, WhiteBitClosedOrder[]>>> GetClosedOrdersAsync(
             string? symbol = null,
             long? orderId = null, 
             string? clientOrderId = null,
@@ -178,7 +178,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitUserTrade[]>> GetUserTradesAsync(string? symbol = null, string? clientOrderId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitUserTrade[]>> GetUserTradesAsync(string? symbol = null, string? clientOrderId = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get trades for a specific order
@@ -193,7 +193,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">["<c>limit</c>"] Max number of results</param>
         /// <param name="offset">["<c>offset</c>"] Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitUserTrade[]>> GetOrderTradesAsync(long orderId, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitUserTrade[]>> GetOrderTradesAsync(long orderId, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit an order
@@ -212,7 +212,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="price">["<c>price</c>"] New price</param>
         /// <param name="triggerPrice">["<c>activationPrice</c>"] New trigger price</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitOrder>> EditOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, decimal? quantity = null, decimal? quoteQuantity = null, decimal? price = null, decimal? triggerPrice = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitOrder>> EditOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, decimal? quantity = null, decimal? quoteQuantity = null, decimal? price = null, decimal? triggerPrice = null, CancellationToken ct = default);
 
         /// <summary>
         /// Set a kill switch. After the specified timeout all order fitting the parameters will be canceled unless the kill switch endpoint is called again to extend or cancel the timeout
@@ -227,7 +227,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="timeout">["<c>timeout</c>"] The timeout in seconds, or 0 to cancel the kill switch</param>
         /// <param name="symbolProductTypes">["<c>types</c>"] Symbol product types</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> SetKillSwitchAsync(string symbol, int timeout, IEnumerable<OrderProductType>? symbolProductTypes = null, CancellationToken ct = default);
+        Task<HttpResult> SetKillSwitchAsync(string symbol, int timeout, IEnumerable<OrderProductType>? symbolProductTypes = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the status of enabled kill switches
@@ -240,6 +240,6 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="symbol">["<c>market</c>"] Filter by symbol</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<WhiteBitKillSwitch[]>> GetKillSwitchStatusAsync(string? symbol = null, CancellationToken ct = default);
+        Task<HttpResult<WhiteBitKillSwitch[]>> GetKillSwitchStatusAsync(string? symbol = null, CancellationToken ct = default);
     }
 }

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitSocketClientV4Api.cs
@@ -24,7 +24,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results</param>
         /// <param name="fromId">Filter by returning results later than the trade with this id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebSocketResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to public trade updates
@@ -71,7 +71,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="symbol">Symbol name</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebSocketResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default);
+        Task<QueryResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default);
         /// <summary>
         /// Subscribe to order book updates
         /// <para><a href="https://docs.whitebit.com/public/websocket/#subscribe-1" /></para>
@@ -97,7 +97,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="symbol">Symbol name</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebSocketResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default);
         /// <summary>
         /// Subscribe to order book updates
         /// <para><a href="https://docs.whitebit.com/public/websocket/#subscribe-2" /></para>
@@ -126,7 +126,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="startTime">Filter by start time</param>
         /// <param name="endTime">Filter by end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebSocketResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -147,7 +147,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="depth">Order book depth, max 100</param>
         /// <param name="priceInterval">0 - no interval default. Available values: "0.00000001", "0.0000001", "0.000001", "0.00001", "0.0001", "0.001", "0.01", "0.1"</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebSocketResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -166,7 +166,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebSocketResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default);
+        Task<QueryResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to spot balance updates
@@ -184,7 +184,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebSocketResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default);
+        Task<QueryResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to margin balance updates
@@ -204,7 +204,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results, max 100</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
-        Task<WebSocketResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to open order updates
@@ -226,7 +226,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results, max 100</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
-        Task<WebSocketResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to closed order updates
@@ -247,7 +247,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results, max 100</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
-        Task<WebSocketResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<QueryResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user trade updates

--- a/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitSocketClientV4Api.cs
+++ b/WhiteBit.Net/Interfaces/Clients/V4Api/IWhiteBitSocketClientV4Api.cs
@@ -24,7 +24,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results</param>
         /// <param name="fromId">Filter by returning results later than the trade with this id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitSocketTrade[]>> GetTradeHistoryAsync(string symbol, int limit, long? fromId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to public trade updates
@@ -34,7 +34,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default);
         
         /// <summary>
         /// Subscribe to public trade updates
@@ -44,7 +44,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTradeUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to public book ticker updates
@@ -54,7 +54,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to public book ticker updates for all symbols
@@ -63,7 +63,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(Action<DataEvent<WhiteBitBookTickerUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the last price for a symbol
@@ -71,7 +71,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="symbol">Symbol name</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default);
+        Task<WebSocketResult<decimal>> GetLastPriceAsync(string symbol, CancellationToken ct = default);
         /// <summary>
         /// Subscribe to order book updates
         /// <para><a href="https://docs.whitebit.com/public/websocket/#subscribe-1" /></para>
@@ -80,7 +80,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(string symbol, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(string symbol, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default);
         /// <summary>
         /// Subscribe to order book updates
         /// <para><a href="https://docs.whitebit.com/public/websocket/#subscribe-1" /></para>
@@ -89,7 +89,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToLastPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitLastPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the ticker for a symbol
@@ -97,7 +97,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="symbol">Symbol name</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitSocketTicker>> GetTickerAsync(string symbol, CancellationToken ct = default);
         /// <summary>
         /// Subscribe to order book updates
         /// <para><a href="https://docs.whitebit.com/public/websocket/#subscribe-2" /></para>
@@ -106,7 +106,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default);
         /// <summary>
         /// Subscribe to order book updates
         /// <para><a href="https://docs.whitebit.com/public/websocket/#subscribe-2" /></para>
@@ -115,7 +115,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitTickerUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get klines for a symbol
@@ -126,7 +126,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="startTime">Filter by start time</param>
         /// <param name="endTime">Filter by end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitKlineUpdate[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -137,7 +137,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<WhiteBitKlineUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<WhiteBitKlineUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the ticker for a symbol
@@ -147,7 +147,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="depth">Order book depth, max 100</param>
         /// <param name="priceInterval">0 - no interval default. Available values: "0.00000001", "0.0000001", "0.000001", "0.00001", "0.0001", "0.001", "0.01", "0.1"</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitOrderBook>> GetOrderBookAsync(string symbol, int depth, string? priceInterval = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -158,7 +158,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, Action<DataEvent<WhiteBitBookUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, Action<DataEvent<WhiteBitBookUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get spot balances
@@ -166,7 +166,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<CallResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitTradeBalance[]>> GetSpotBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to spot balance updates
@@ -176,7 +176,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSpotBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<Dictionary<string, WhiteBitTradeBalance>>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSpotBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<Dictionary<string, WhiteBitTradeBalance>>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get margin balances
@@ -184,7 +184,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// </summary>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<CallResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to margin balance updates
@@ -194,7 +194,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToMarginBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<WhiteBitMarginBalance[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToMarginBalanceUpdatesAsync(IEnumerable<string> assets, Action<DataEvent<WhiteBitMarginBalance[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get open orders
@@ -204,7 +204,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results, max 100</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
-        Task<CallResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitOrders>> GetOpenOrdersAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to open order updates
@@ -215,7 +215,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onOtoOrdersMessage">The event handler for handling an OTO order update</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitOrderUpdate>> onOrderMessage, Action<DataEvent<WhiteBitOtoOrderUpdate>>? onOtoOrdersMessage = null, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitOrderUpdate>> onOrderMessage, Action<DataEvent<WhiteBitOtoOrderUpdate>>? onOtoOrdersMessage = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get closed orders
@@ -226,7 +226,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results, max 100</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
-        Task<CallResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitClosedOrders>> GetClosedOrdersAsync(string symbol, IEnumerable<OrderType>? orderTypes = null, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to closed order updates
@@ -237,7 +237,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToClosedOrderUpdatesAsync(IEnumerable<string> symbols, ClosedOrderFilter filter, Action<DataEvent<WhiteBitClosedOrder[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToClosedOrderUpdatesAsync(IEnumerable<string> symbols, ClosedOrderFilter filter, Action<DataEvent<WhiteBitClosedOrder[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get user trades
@@ -247,7 +247,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="limit">Max number of results, max 100</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
-        Task<CallResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<WebSocketResult<WhiteBitUserTrades>> GetUserTradesAsync(string symbol, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user trade updates
@@ -257,7 +257,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitUserTradeUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<WhiteBitUserTradeUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to position updates
@@ -266,7 +266,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<WhiteBitPositionsUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<WhiteBitPositionsUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to borrow updates
@@ -275,7 +275,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBorrowUpdatesAsync(Action<DataEvent<WhiteBitBorrow>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBorrowUpdatesAsync(Action<DataEvent<WhiteBitBorrow>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user margin call and liquidation events
@@ -284,7 +284,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToAccountBorrowEventUpdatesAsync(Action<DataEvent<WhiteBitAccountBorrowUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToAccountBorrowEventUpdatesAsync(Action<DataEvent<WhiteBitAccountBorrowUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to position margin call and liquidation events
@@ -293,7 +293,7 @@ namespace WhiteBit.Net.Interfaces.Clients.V4Api
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToAccountMarginPositionEventUpdatesAsync(Action<DataEvent<WhiteBitAccountMarginPositionUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToAccountMarginPositionEventUpdatesAsync(Action<DataEvent<WhiteBitAccountMarginPositionUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the shared socket requests client. This interface is shared with other exchanges to allow for a common implementation for different exchanges.

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitBookSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitBookSubscription.cs
@@ -32,7 +32,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _depth = depth;
             Topic = "OrderBook";
 
-            MessageRouter = MessageRouter.CreateWithTopicFilter<WhiteBitSocketUpdate<WhiteBitBookUpdate>>("depth_update", symbol, DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<WhiteBitSocketUpdate<WhiteBitBookUpdate>>("depth_update", symbol, DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -70,7 +70,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                     .WithUpdateType(message.Data!.Snapshot ? SocketUpdateType.Snapshot : SocketUpdateType.Update)
                     .WithSequenceNumber(message.Data.OrderBook.UpdateId)
                 );
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitClosedOrderSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitClosedOrderSubscription.cs
@@ -32,7 +32,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _handler = handler;
             _symbols = symbols.ToArray();
             _orderFilter = orderFilter;
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<WhiteBitSocketUpdate<WhiteBitClosedOrder[]>>("depth_update", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<WhiteBitSocketUpdate<WhiteBitClosedOrder[]>>("depth_update", DoHandleMessage);
             Topic = "ClosedOrder";
         }
 
@@ -68,7 +68,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                     .WithUpdateType(SocketUpdateType.Update)
                 );
 
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitKlineSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitKlineSubscription.cs
@@ -34,7 +34,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _interval = interval;
             Topic = "Klines";
 
-            MessageRouter = MessageRouter.CreateWithTopicFilter<WhiteBitSocketUpdate<WhiteBitKlineUpdate[]>>("candles_update", symbol, DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<WhiteBitSocketUpdate<WhiteBitKlineUpdate[]>>("candles_update", symbol, DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -69,7 +69,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                     .WithUpdateType(SocketUpdateType.Update)
                 );
 
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitMarginBalanceSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitMarginBalanceSubscription.cs
@@ -32,7 +32,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _symbols = symbols.ToArray();
             Topic = "MarginBalance";
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<WhiteBitSocketUpdate<WhiteBitMarginBalance[]>>("balanceMargin_update", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<WhiteBitSocketUpdate<WhiteBitMarginBalance[]>>("balanceMargin_update", DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -65,7 +65,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                     .WithUpdateType(SocketUpdateType.Update)
                 );
 
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitOpenOrderSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitOpenOrderSubscription.cs
@@ -39,8 +39,8 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             var routes = new List<MessageRoute>();
             foreach (var symbol in symbols)
             {
-                routes.Add(MessageRoute<WhiteBitSocketUpdate<WhiteBitOrderUpdate>>.CreateWithTopicFilter("ordersPending_update", symbol, DoHandleMessage));
-                routes.Add(MessageRoute<WhiteBitSocketUpdate<WhiteBitOtoOrderUpdate>>.CreateWithTopicFilter("otoOrdersPending_update", symbol, DoHandleMessage));
+                routes.Add(EventRoute<WhiteBitSocketUpdate<WhiteBitOrderUpdate>>.CreateWithTopicFilter("ordersPending_update", symbol, DoHandleMessage));
+                routes.Add(EventRoute<WhiteBitSocketUpdate<WhiteBitOtoOrderUpdate>>.CreateWithTopicFilter("otoOrdersPending_update", symbol, DoHandleMessage));
             }
 
             MessageRouter = MessageRouter.Create(routes.ToArray());
@@ -77,7 +77,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                         .WithSymbol(message.Data!.Order.TriggerOrder?.Symbol)
                         .WithUpdateType(SocketUpdateType.Update)
                 );
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -89,7 +89,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                         .WithSymbol(message.Data!.Order.Symbol)
                         .WithUpdateType(SocketUpdateType.Update)
                 );
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitSpotBalanceSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitSpotBalanceSubscription.cs
@@ -32,7 +32,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _symbols = symbols.ToArray();
             Topic = "SpotBalance";
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<WhiteBitSocketUpdate<Dictionary<string, WhiteBitTradeBalance>[]>>("balanceSpot_update", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<WhiteBitSocketUpdate<Dictionary<string, WhiteBitTradeBalance>[]>>("balanceSpot_update", DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -67,7 +67,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _handler.Invoke(
                 new DataEvent<Dictionary<string, WhiteBitTradeBalance>>(WhiteBitExchange.ExchangeName, balances, receiveTime, originalData)
                     .WithUpdateType(SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitSubscription.cs
@@ -31,9 +31,11 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             _symbols = symbols;
             Topic = topic;
 
-            IndividualSubscriptionCount = symbols?.Length ?? 1;
+            IndividualSubscriptionCount = symbols?.Length == 0 ? 1 : symbols?.Length ?? 1;
 
-            MessageRouter = MessageRouter.CreateWithOptionalTopicFilters<WhiteBitSocketUpdate<T>>($"{topic}_update", symbols, DoHandleMessage);
+            MessageRouter = symbols?.Length > 0
+                ? MessageRouter.CreateForEvent<WhiteBitSocketUpdate<T>>($"{topic}_update", symbols, DoHandleMessage)
+                : MessageRouter.CreateForEvent<WhiteBitSocketUpdate<T>>($"{topic}_update", DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -62,7 +64,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, WhiteBitSocketUpdate<T> message)
         {
             _handler.Invoke(receiveTime, originalData, ConnectionInvocations, message);
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitUserTradeSubscription.cs
+++ b/WhiteBit.Net/Objects/Sockets/Subscriptions/WhiteBitUserTradeSubscription.cs
@@ -35,7 +35,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
             IndividualSubscriptionCount = symbols.Length;
 
             Topic = "UserTrade";
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<WhiteBitSocketUpdate<WhiteBitUserTradeUpdate>>("deals_update", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<WhiteBitSocketUpdate<WhiteBitUserTradeUpdate>>("deals_update", DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -72,7 +72,7 @@ namespace WhiteBit.Net.Objects.Sockets.Subscriptions
                 .WithDataTimestamp(message.Data.Time, _client.GetTimeOffset())
                 .WithUpdateType(SocketUpdateType.Update)
                 );
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/WhiteBit.Net/Objects/Sockets/WhiteBitQuery.cs
+++ b/WhiteBit.Net/Objects/Sockets/WhiteBitQuery.cs
@@ -16,15 +16,15 @@ namespace WhiteBit.Net.Objects.Sockets
         {
             _client = client;
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<WhiteBitSocketResponse<T>>(request.Id.ToString(), HandleMessage);
+            MessageRouter = MessageRouter.CreateForQuery<WhiteBitSocketResponse<T>>(request.Id.ToString(), HandleMessage);
         }
 
         public CallResult<WhiteBitSocketResponse<T>> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, WhiteBitSocketResponse<T> message)
         {
             if (message.Error != null)
-                return new CallResult<WhiteBitSocketResponse<T>>(new ServerError(message.Error.Code, _client.GetErrorInfo(message.Error.Code, message.Error.Message)));
+                return CallResult.Fail<WhiteBitSocketResponse<T>>(new ServerError(message.Error.Code, _client.GetErrorInfo(message.Error.Code, message.Error.Message)));
 
-            return new CallResult<WhiteBitSocketResponse<T>>(message, originalData, null);
+            return CallResult<WhiteBitSocketResponse<T>>.Ok(message, originalData);
         }
     }
 }

--- a/WhiteBit.Net/Objects/WhiteBitApiAddresses.cs
+++ b/WhiteBit.Net/Objects/WhiteBitApiAddresses.cs
@@ -22,5 +22,14 @@ namespace WhiteBit.Net.Objects
             RestClientAddress = "https://whitebit.com",
             SocketClientAddress = "wss://api.whitebit.com"
         };
+
+        /// <summary>
+        /// The addresses to connect to the WhiteBit Europe API
+        /// </summary>
+        public static WhiteBitApiAddresses Europe = new WhiteBitApiAddresses
+        {
+            RestClientAddress = "https://whitebit.eu",
+            SocketClientAddress = "wss://api.whitebit.eu"
+        };
     }
 }

--- a/WhiteBit.Net/SymbolOrderBooks/WhiteBitV4SymbolOrderBook.cs
+++ b/WhiteBit.Net/SymbolOrderBooks/WhiteBitV4SymbolOrderBook.cs
@@ -68,22 +68,22 @@ namespace WhiteBit.Net.SymbolOrderBooks
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
             var result = await _socketClient.V4Api.SubscribeToOrderBookUpdatesAsync(Symbol, Levels!.Value, ProcessUpdate).ConfigureAwait(false);
-            if (!result)
-                return result;
+            if (!result.Success)
+                return CallResult.Fail<UpdateSubscription>(result.Error!);
 
             if (ct.IsCancellationRequested)
             {
                 await result.Data.CloseAsync().ConfigureAwait(false);
-                return result.AsError<UpdateSubscription>(new CancellationRequestedError());
+                return CallResult.Fail<UpdateSubscription>(new CancellationRequestedError());
             }
 
             Status = OrderBookStatus.Syncing;
 
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!setResult)
+            if (!setResult.Success)
                 await result.Data.CloseAsync().ConfigureAwait(false);
 
-            return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
+            return setResult.Success ? CallResult.Ok(result.Data) : CallResult.Fail<UpdateSubscription>(setResult.Error!);
         }
 
 
@@ -106,7 +106,7 @@ namespace WhiteBit.Net.SymbolOrderBooks
         }
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/WhiteBit.Net/WhiteBit.Net.csproj
+++ b/WhiteBit.Net/WhiteBit.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/WhiteBit.Net/WhiteBit.Net.csproj
+++ b/WhiteBit.Net/WhiteBit.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="11.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/WhiteBit.Net/WhiteBitAuthenticationProvider.cs
+++ b/WhiteBit.Net/WhiteBitAuthenticationProvider.cs
@@ -28,7 +28,7 @@ namespace WhiteBit.Net
                 return;
 
             var nonce = _nonceProvider.GetNonce().ToString();
-            request.BodyParameters ??= new Dictionary<string, object>();
+            request.BodyParameters ??= new Parameters(WhiteBitExchange._parameterSerializationSettings);
             request.BodyParameters.Add("request", request.Path);
             request.BodyParameters.Add("nonce", nonce);
             request.BodyParameters.Add("nonceWindow", ((WhiteBitRestOptions)apiClient.ClientOptions).EnableNonceWindow);

--- a/WhiteBit.Net/WhiteBitAuthenticationProvider.cs
+++ b/WhiteBit.Net/WhiteBitAuthenticationProvider.cs
@@ -24,12 +24,12 @@ namespace WhiteBit.Net
 
         public override void ProcessRequest(RestApiClient apiClient, RestRequestConfiguration request)
         {
-            if (!request.Authenticated)
+            if (!request.RequestDefinition.Authenticated)
                 return;
 
             var nonce = _nonceProvider.GetNonce().ToString();
             request.BodyParameters ??= new Parameters(WhiteBitExchange._parameterSerializationSettings);
-            request.BodyParameters.Add("request", request.Path);
+            request.BodyParameters.Add("request", request.RequestDefinition.Path);
             request.BodyParameters.Add("nonce", nonce);
             request.BodyParameters.Add("nonceWindow", ((WhiteBitRestOptions)apiClient.ClientOptions).EnableNonceWindow);
             request.Headers ??= new Dictionary<string, string>();

--- a/WhiteBit.Net/WhiteBitEnvironment.cs
+++ b/WhiteBit.Net/WhiteBitEnvironment.cs
@@ -43,6 +43,7 @@ namespace WhiteBit.Net
          => name switch
          {
              TradeEnvironmentNames.Live => Live,
+             "Europe" => Europe,
              "" => Live,
              null => Live,
              _ => default
@@ -61,6 +62,14 @@ namespace WhiteBit.Net
             = new WhiteBitEnvironment(TradeEnvironmentNames.Live,
                                      WhiteBitApiAddresses.Default.RestClientAddress,
                                      WhiteBitApiAddresses.Default.SocketClientAddress);
+
+        /// <summary>
+        /// Europe environment
+        /// </summary>
+        public static WhiteBitEnvironment Europe { get; }
+            = new WhiteBitEnvironment("Europe",
+                                     WhiteBitApiAddresses.Europe.RestClientAddress,
+                                     WhiteBitApiAddresses.Europe.SocketClientAddress);
 
         /// <summary>
         /// Create a custom environment

--- a/WhiteBit.Net/WhiteBitExchange.cs
+++ b/WhiteBit.Net/WhiteBitExchange.cs
@@ -102,7 +102,7 @@ namespace WhiteBit.Net
         /// <summary>
         /// Rate limiter configuration for the WhiteBit API
         /// </summary>
-        public static WhiteBitRateLimiters RateLimiter { get; } = new WhiteBitRateLimiters();
+        public static WhiteBitRateLimiters RateLimiter { get; set; } = new WhiteBitRateLimiters();
     }
 
     /// <summary>
@@ -121,13 +121,19 @@ namespace WhiteBit.Net
         public event Action<RateLimitUpdateEvent> RateLimitUpdated;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal WhiteBitRateLimiters()
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public WhiteBitRateLimiters()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             Initialize();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize the rate limits
+        /// </summary>
+        protected virtual void Initialize()
         {
             WhiteBit = new RateLimitGate("WhiteBit");
             WhiteBitSocket = new RateLimitGate("WhiteBit Socket")

--- a/WhiteBit.Net/WhiteBitExchange.cs
+++ b/WhiteBit.Net/WhiteBitExchange.cs
@@ -27,7 +27,8 @@ namespace WhiteBit.Net
                 "https://www.whitebit.com",
                 ["https://docs.whitebit.com/"],
                 PlatformType.CryptoCurrencyExchange,
-                CentralizationType.Centralized
+                CentralizationType.Centralized,
+                WhiteBitEnvironment.All
                 );
 
         /// <summary>

--- a/WhiteBit.Net/WhiteBitExchange.cs
+++ b/WhiteBit.Net/WhiteBitExchange.cs
@@ -63,6 +63,11 @@ namespace WhiteBit.Net
         public static ExchangeType Type { get; } = ExchangeType.CEX;
 
         internal static JsonSerializerOptions _serializerContext = SerializerOptions.WithConverters(JsonSerializerContextCache.GetOrCreate<WhiteBitSourceGenerationContext>(), new ClosedOrdersConverter());
+        internal static ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
 
         /// <summary>
         /// Aliases for WhiteBit assets

--- a/WhiteBit.Net/WhiteBitUserDataTracker.cs
+++ b/WhiteBit.Net/WhiteBitUserDataTracker.cs
@@ -20,7 +20,6 @@ namespace WhiteBit.Net
             SpotUserDataTrackerConfig? config) : base(
                 logger,
                 restClient.V4Api.SharedClient,
-                null,
                 restClient.V4Api.SharedClient,
                 socketClient.V4Api.SharedClient,
                 restClient.V4Api.SharedClient,
@@ -48,7 +47,6 @@ namespace WhiteBit.Net
             string? userIdentifier,
             FuturesUserDataTrackerConfig? config) : base(logger,
                 restClient.V4Api.SharedClient,
-                null,
                 restClient.V4Api.SharedClient,
                 socketClient.V4Api.SharedClient,
                 restClient.V4Api.SharedClient,

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -163,6 +163,7 @@ Use this file to route common user intents to the correct WhiteBit.Net client me
 | Shared order book socket | `IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(...)` |
 | Shared user trade socket | `IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(...)` |
 | Shared position socket | `IPositionSocketClient.SubscribeToPositionUpdatesAsync(...)` |
+| Discover shared capabilities | `client.V4Api.SharedClient.Discover()` |
 
 For shared socket subscriptions, keep the concrete socket client and unsubscribe with `await socketClient.UnsubscribeAsync(subscription.Data)`.
 
@@ -170,9 +171,11 @@ For shared socket subscriptions, keep the concrete socket client and unsubscribe
 
 | Situation | Pattern |
 |---|---|
-| REST success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
-| Socket subscription success check | `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
-| Read REST data | Read `result.Data` only after `result.Success` |
+| REST success check | Direct and shared REST methods return `HttpResult<T>` / `HttpResult` |
+| Socket request success check | WebSocket request/response calls return `QueryResult<T>` |
+| Socket subscription success check | Direct and shared subscriptions return `WebSocketResult<UpdateSubscription>` |
+| Generic success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
+| Read result data | Read `result.Data` only after `result.Success` |
 | Retry decision | Retry only when `result.Error?.IsTransient == true` |
 | Cancellation | Pass `ct: cancellationToken` |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 WhiteBit.Net is a strongly typed .NET client library for the WhiteBit REST and WebSocket APIs. It is part of the CryptoExchange.Net ecosystem and uses the same result, shared API, logging, rate limiting, and socket patterns as other JKorf exchange libraries.
 
 Current package version in this repository: 3.11.1.
-CryptoExchange.Net dependency: 11.1.0.
+CryptoExchange.Net dependency on this branch: 12.0.0-beta1.
 Target frameworks: netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 Native AOT: supported on compatible .NET targets.
 
@@ -24,8 +24,10 @@ Primary documentation:
 - Include `using WhiteBit.Net;` when using `WhiteBitCredentials` or `WhiteBitEnvironment`.
 - Direct client calls are rooted at `V4Api`; do not generate `SpotApi`, `FuturesApi`, or `GeneralApi` members.
 - Always check `.Success` before reading `.Data`.
-- REST methods return `HttpResult<T>` or `HttpResult`.
-- WebSocket requests and subscriptions return `WebSocketResult<T>` or `CallResult`.
+- Direct REST and SharedApis REST methods return `HttpResult<T>` or `HttpResult`.
+- WebSocket request/response methods return `QueryResult<T>`.
+- Direct and SharedApis WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`.
+- SharedApis helper methods that do not perform HTTP/socket I/O can return `ExchangeCallResult<T>`.
 - Reuse clients. Do not instantiate a REST or socket client per request in production code.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -395,7 +397,7 @@ if (!ticker.Success)
 Console.WriteLine(ticker.Data.LastPrice);
 ```
 
-Shared WebSocket subscriptions return an `UpdateSubscription` in `.Data`. For shared interface variables, unsubscribe through the concrete socket client:
+Shared WebSocket subscriptions return `WebSocketResult<UpdateSubscription>` with the subscription in `.Data`. For shared interface variables, unsubscribe through the concrete socket client:
 
 ```csharp
 var socketClient = new WhiteBitSocketClient();
@@ -417,6 +419,8 @@ await socketClient.UnsubscribeAsync(sub.Data);
 ```
 
 Do not call `tickerSocket.UnsubscribeAsync(...)` on `ITickerSocketClient`; that shared interface does not expose the method.
+
+Shared clients also expose `Discover()` for runtime capability discovery. Use it when tooling or exchange-agnostic code needs to inspect implemented shared interfaces and endpoint option metadata instead of hard-coding assumptions.
 
 ## Symbol And Quantity Handling
 
@@ -466,7 +470,7 @@ Examples/ai-friendly/03-websocket.cs
   Public ticker stream, kline stream, authenticated balance/order streams, success checks, teardown.
 
 Examples/ai-friendly/04-multi-exchange.cs
-  CryptoExchange.Net SharedApis REST and socket patterns.
+  CryptoExchange.Net SharedApis REST and socket patterns, including concrete socket-client teardown.
 
 Examples/ai-friendly/05-error-handling.cs
   HttpResult pattern, transient retry, WhiteBit validation examples, symbol metadata handling.
@@ -481,6 +485,7 @@ Before finalizing generated code:
 - Does it compile with the current package?
 - Does it include `using WhiteBit.Net;` when using credentials or environments?
 - Does every REST/socket result check `.Success` before `.Data`?
+- For socket request/response methods, does it expect `QueryResult<T>` rather than `HttpResult<T>`?
 - Does it use the correct API branch: `V4Api.ExchangeData`, `Account`, `Trading`, `CollateralTrading`, `Convert`, `Codes`, or `SubAccount`?
 - Does it avoid raw WhiteBit URLs and manual signing?
 - Does it avoid nonexistent `WhiteBitClient`, `SpotApi`, `FuturesApi`, and `GeneralApi` members?

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,8 +24,8 @@ Primary documentation:
 - Include `using WhiteBit.Net;` when using `WhiteBitCredentials` or `WhiteBitEnvironment`.
 - Direct client calls are rooted at `V4Api`; do not generate `SpotApi`, `FuturesApi`, or `GeneralApi` members.
 - Always check `.Success` before reading `.Data`.
-- REST methods return `WebCallResult<T>` or `WebCallResult`.
-- WebSocket requests and subscriptions return `CallResult<T>` or `CallResult`.
+- REST methods return `HttpResult<T>` or `HttpResult`.
+- WebSocket requests and subscriptions return `WebSocketResult<T>` or `CallResult`.
 - Reuse clients. Do not instantiate a REST or socket client per request in production code.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -163,9 +163,9 @@ Console.WriteLine(ticker.LastPrice);
 Retry only transient errors:
 
 ```csharp
-async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> call, int maxAttempts = 3)
+async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
 
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -469,7 +469,7 @@ Examples/ai-friendly/04-multi-exchange.cs
   CryptoExchange.Net SharedApis REST and socket patterns.
 
 Examples/ai-friendly/05-error-handling.cs
-  WebCallResult pattern, transient retry, WhiteBit validation examples, symbol metadata handling.
+  HttpResult pattern, transient retry, WhiteBit validation examples, symbol metadata handling.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package WhiteBit.Net`.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the WhiteBit REST and WebSocket APIs. Supports V4 public market data, spot trading, collateral/futures trading, balances, deposits, withdrawals, convert, WhiteBit Codes, sub-accounts, private WebSocket streams, local order books, and CryptoExchange.Net shared APIs.
 
-WhiteBit.Net is part of the CryptoExchange.Net ecosystem. It uses `HttpResult<T>` / `WebSocketResult<T>` for error-aware results, supports client-side rate limiting, automatic WebSocket reconnection, dependency injection, native AOT, and shared API abstractions for multi-exchange applications. Current repository package version: 3.11.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+WhiteBit.Net is part of the CryptoExchange.Net ecosystem. It uses `HttpResult<T>` for REST, `QueryResult<T>` for WebSocket request/response calls, and `WebSocketResult<UpdateSubscription>` for WebSocket subscriptions. Shared REST APIs use the same `HttpResult<T>` pattern. It supports client-side rate limiting, automatic WebSocket reconnection, dependency injection, native AOT, and shared API abstractions for multi-exchange applications. Current repository package version: 3.11.1. This branch targets CryptoExchange.Net 12.0.0-beta1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -31,6 +31,7 @@ WhiteBit.Net is part of the CryptoExchange.Net ecosystem. It uses `HttpResult<T>
 - For spot orders use `restClient.V4Api.Trading.PlaceSpotOrderAsync`.
 - For collateral/futures orders use `restClient.V4Api.CollateralTrading.PlaceOrderAsync`.
 - For multi-exchange code use `CryptoExchange.Net.SharedApis` from `.V4Api.SharedClient`.
+- Use `SharedClient.Discover()` when code needs to inspect implemented shared interfaces and endpoint options at runtime.
 - Store WebSocket subscriptions and call `socketClient.UnsubscribeAsync(subscription.Data)`.
 
 ## Reference

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the WhiteBit REST and WebSocket APIs. Supports V4 public market data, spot trading, collateral/futures trading, balances, deposits, withdrawals, convert, WhiteBit Codes, sub-accounts, private WebSocket streams, local order books, and CryptoExchange.Net shared APIs.
 
-WhiteBit.Net is part of the CryptoExchange.Net ecosystem. It uses `WebCallResult<T>` / `CallResult<T>` for error-aware results, supports client-side rate limiting, automatic WebSocket reconnection, dependency injection, native AOT, and shared API abstractions for multi-exchange applications. Current repository package version: 3.11.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+WhiteBit.Net is part of the CryptoExchange.Net ecosystem. It uses `HttpResult<T>` / `WebSocketResult<T>` for error-aware results, supports client-side rate limiting, automatic WebSocket reconnection, dependency injection, native AOT, and shared API abstractions for multi-exchange applications. Current repository package version: 3.11.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -19,7 +19,7 @@ WhiteBit.Net is part of the CryptoExchange.Net ecosystem. It uses `WebCallResult
 - [Collateral/Futures Trading](https://github.com/JKorf/WhiteBit.Net/blob/main/Examples/ai-friendly/02-collateral-futures.cs): Leverage, collateral order, positions, reduce-only close
 - [WebSocket Streams](https://github.com/JKorf/WhiteBit.Net/blob/main/Examples/ai-friendly/03-websocket.cs): Public ticker/kline streams and private order/balance streams with teardown
 - [Multi-Exchange Pattern](https://github.com/JKorf/WhiteBit.Net/blob/main/Examples/ai-friendly/04-multi-exchange.cs): CryptoExchange.Net SharedApis usage
-- [Error Handling](https://github.com/JKorf/WhiteBit.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): `WebCallResult` checks, transient retry, validation handling
+- [Error Handling](https://github.com/JKorf/WhiteBit.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): `HttpResult` checks, transient retry, validation handling
 
 ## Critical Rules
 


### PR DESCRIPTION
* Result types:
  * (Web)CallResult types are replaced by HttpResult, WebSocketResult and QueryResult with the same logic
  * WebSocketResult and QueryResult now return additional info for websocket operations
  * Updated result types to record type
  * Removed implicit result type conversion to bool, `if (result)` no longer works, instead use `if (result.Success)`
  * Fixed result object nullability hinting, for example Data might be null if Success isn't checked for true

* Clients:
  * Added ToString overrides on base API types
  * Added Exchange property on BaseApiClient
  * Added ApiCredentials property on Api clients
  * Updated ILogger source from client name to topic specific client name
  * Removed logging from client creation
  * Fixed issue in SocketApiClient.GetSocketConnection causing requests to always wait the full max 10 seconds when there was a reconnecting socket

* Shared APIs:
  * Added missing dedicated option types
  * Added Discover method on ISharedClient interface, returning info on supported capabilities and operations
  * Added ResetStaticExchangeParameters method on ExchangeParameters
  * Added Status property to SharedWithdrawal model
  * Added TradingModes property to SharedBalance model
  * Updated Shared ExchangeParameters parameter names to be case insensitive
  * Updated code comments
  * Replaced ExchangeResult with ExchangeCallResult type
  * Removed TradingMode from the response model, only maintained on models where it makes sense

* Added Europe environment
* Added async streaming on UserDataTracker items with StreamUpdatesAsync
* Added cancellation token support to UserDataTracker starting
* Added SupportedEnvironments property to PlatformInfo
* Added Clear() method on UserClientProvider to clear all cached clients
* Added setter to WhiteBitExchange.RateLimiter to allow custom rate limit settings
* Various small performance improvements
* Fixed websocket connection attempts counting towards rate limit even when server could not be reached
