### PR TITLE
Fixed GetConvertHistory startTime, endTime parameter conversion

### DIFF
--- a/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
+++ b/WhiteBit.Net/Clients/V4Api/WhiteBitRestClientV4ApiConvert.cs
@@ -62,8 +62,8 @@ namespace WhiteBit.Net.Clients.V4Api
             parameters.Add("fromTicker", fromAsset);
             parameters.Add("toTicker", toAsset);
             parameters.Add("quoteId", quoteId);
-            parameters.Add("from", startTime);
-            parameters.Add("to", endTime);
+            parameters.Add("from", startTime, DateTimeSerialization.SecondsString);
+            parameters.Add("to", endTime, DateTimeSerialization.SecondsString);
             parameters.Add("limit", limit);
             parameters.Add("offset", offset);
             var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v4/convert/history", WhiteBitExchange.RateLimiter.WhiteBit, 1, true,


### PR DESCRIPTION
Fixed a bug that was reintroduced with the latest changes.
Was already fixed before with PR #23 