### PR TITLE
Convert date time to seconds for Whitebit compatibility

### DIFF
--- a/WhiteBit.Net/WhiteBitExchange.cs
+++ b/WhiteBit.Net/WhiteBitExchange.cs
@@ -67,6 +67,7 @@ namespace WhiteBit.Net
         internal static ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings
         {
             Decimal = DecimalSerialization.String,
+            DateTimes = DateTimeSerialization.SecondsNumber,
             Sort = false
         };
 


### PR DESCRIPTION
Fixing #29. WhiteBit is using epoch unix seconds as a timestamp, but in current implementation milliseconds were used.
These changes set a correct timestamp conversation type.